### PR TITLE
sexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ Mainly, almost all keybinding settings are derived from [vscode-emacs-friendly b
 | `C-x 4` | Toggle split layout (vertical to horizontal) |
 | `C-x o` | Focus other split editor |
 
+### sexp
+|Command | Desc |
+|--------|------|
+| `C-M-f` (`Alt+K`) | Move forward by one s-exp |
+| `C-M-b` (`Alt+J`) | Move backward by one s-exp |
+| `C-M-SPC` (`Alt+I`) | Slurp one s-exp forward |
+| `C-M-S-SPC` (`Alt+U`) | Barf one s-exp to the front |
+
+These sexp functionalities are provided [sexp](https://marketplace.visualstudio.com/items?itemName=haruhi-s.sexp) extension by **haruhi-s**.
+Thanks to haruhi-s.
+[sexp](https://marketplace.visualstudio.com/items?itemName=haruhi-s.sexp) is declared as an Awesome Emacs Keymap's dependency so that it is also installed together.
+
 ## Conflicts with default key bindings
 - `ctrl+d`: editor.action.addSelectionToNextFindMatch => **Use `ctrl+alt+n` instead**;
 - `ctrl+g`: workbench.action.gotoLine => **Use `alt+g g` instead**;

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
 				"*"
 		],
 		"main": "./out/extension.js",
+		"extensionDependencies": [
+			"haruhi-s.sexp"
+		],
 		"contributes": {
 				"keybindings": [
 						{
@@ -643,6 +646,28 @@
 								"key": "alt+backspace",
 								"command": "deleteWordLeft",
 								"when": "editorTextFocus && !editorReadonly"
+						},
+
+
+						{
+								"key": "ctrl+alt+f",
+								"command": "sexp.moveForward",
+								"when": "editorTextFocus"
+						},
+						{
+								"key": "ctrl+alt+b",
+								"command": "sexp.moveBackward",
+								"when": "editorTextFocus"
+						},
+						{
+								"command": "sexp.barf",
+								"key": "ctrl+alt+shift+space",
+								"when": "editorTextFocus"
+						},
+						{
+								"command": "sexp.slurp",
+								"key": "ctrl+alt+space",
+								"when": "editorTextFocus"
 						}
 				]
 		},


### PR DESCRIPTION
Close #27 

For sexp functionalities, [sexp](https://marketplace.visualstudio.com/items?itemName=haruhi-s.sexp) extension will be used as an external extension dependency.
Awesome Emacs Keymap defines new keybindings to the sexp commands to use them like emacs.