### PR TITLE
C-u (universal argument)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ Mainly, almost all keybinding settings are derived from [vscode-emacs-friendly b
 | `C-x 4` | Toggle split layout (vertical to horizontal) |
 | `C-x o` | Focus other split editor |
 
+### Prefix argument
+|Command | Desc |
+|--------|------|
+| `C-u` | universal-argument (See https://www.gnu.org/software/emacs/manual/html_node/emacs/Arguments.html for detail) |
+
 ### sexp
 |Command | Desc |
 |--------|------|

--- a/package.json
+++ b/package.json
@@ -663,6 +663,11 @@
 								"when": "editorTextFocus && !editorReadonly"
 						},
 						{
+								"key": "ctrl+u",
+								"command": "emacs-mcx.universalArgument",
+								"when": "editorTextFocus"
+						},
+						{
 								"key": "ctrl+alt+f",
 								"command": "sexp.moveForward",
 								"when": "editorTextFocus"

--- a/package.json
+++ b/package.json
@@ -664,7 +664,7 @@
 						},
 						{
 								"key": "ctrl+u",
-								"command": "emacs-mcx.prefixArgument",
+								"command": "emacs-mcx.universalArgument",
 								"when": "editorTextFocus"
 						},
 						{

--- a/package.json
+++ b/package.json
@@ -664,7 +664,7 @@
 						},
 						{
 								"key": "ctrl+u",
-								"command": "emacs-mcx.universalArgument",
+								"command": "emacs-mcx.prefixArgument",
 								"when": "editorTextFocus"
 						},
 						{

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -16,7 +16,7 @@ export class EmacsEmulator implements Disposable {
     private recenterer: Recenterer;
 
     private isInUniversalArgumentMode = false;
-    private universalArgument: string = "";
+    private universalArgumentStr: string = "";
 
     constructor(textEditor: TextEditor, killRing: KillRing | null = null) {
         this.textEditor = textEditor;
@@ -63,14 +63,12 @@ export class EmacsEmulator implements Disposable {
 
         if (!isNaN(+text)) {
             // If `text` is a numeric charactor
-            this.universalArgument += text;
+            this.universalArgumentStr += text;
             return;
         }
 
-        let universalArgument = parseInt(this.universalArgument, 10);
-        if (isNaN(universalArgument)) {
-            universalArgument = 4;
-        }
+        const universalArgument = this.getUniversalArgument();
+        if (universalArgument === undefined) { return; }
 
         this.exitUniversalArgumentMode();
         const promises = [];
@@ -86,12 +84,22 @@ export class EmacsEmulator implements Disposable {
 
     public enterUniversalArgumentMode() {
         this.isInUniversalArgumentMode = true;
-        this.universalArgument = "";
+        this.universalArgumentStr = "";
     }
 
     public exitUniversalArgumentMode() {
         this.isInUniversalArgumentMode = false;
-        this.universalArgument = "";
+        this.universalArgumentStr = "";
+    }
+
+    public getUniversalArgument(): number | undefined {
+        if (!this.isInUniversalArgumentMode) { return undefined; }
+
+        const universalArgument = parseInt(this.universalArgumentStr, 10);
+        if (isNaN(universalArgument)) {
+            return 4;
+        }
+        return universalArgument;
     }
 
     public cursorMove(commandName: cursorMoves) {

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -16,7 +16,9 @@ export class EmacsEmulator implements Disposable {
     private recenterer: Recenterer;
 
     private isInPrefixArgumentMode = false;
-    private prefixArgumentStr: string = "";
+    private isAcceptingPrefixArgument = false;
+    private cuCount = 0;  // How many C-u are input continuously
+    private prefixArgumentStr = "";  // Prefix argument string input after C-u
 
     constructor(textEditor: TextEditor, killRing: KillRing | null = null) {
         this.textEditor = textEditor;
@@ -64,7 +66,7 @@ export class EmacsEmulator implements Disposable {
             });
         }
 
-        if (!isNaN(+text)) {
+        if (this.isAcceptingPrefixArgument && !isNaN(+text)) {
             // If `text` is a numeric charactor
             this.prefixArgumentStr += text;
             return;
@@ -86,12 +88,20 @@ export class EmacsEmulator implements Disposable {
     }
 
     public enterPrefixArgumentMode() {
-        this.isInPrefixArgumentMode = true;
-        this.prefixArgumentStr = "";
+        if (this.isInPrefixArgumentMode && this.prefixArgumentStr.length > 0) {
+            this.isAcceptingPrefixArgument = false;
+        } else {
+            this.isInPrefixArgumentMode = true;
+            this.isAcceptingPrefixArgument = true;
+            this.cuCount++;
+            this.prefixArgumentStr = "";
+        }
     }
 
     public exitPrefixArgumentMode() {
         this.isInPrefixArgumentMode = false;
+        this.isAcceptingPrefixArgument = false;
+        this.cuCount = 0;
         this.prefixArgumentStr = "";
     }
 
@@ -100,7 +110,7 @@ export class EmacsEmulator implements Disposable {
 
         const prefixArgument = parseInt(this.prefixArgumentStr, 10);
         if (isNaN(prefixArgument)) {
-            return 4;
+            return 4 ** this.cuCount;
         }
         return prefixArgument;
     }

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -15,8 +15,8 @@ export class EmacsEmulator implements Disposable {
     private killYanker: KillYanker;
     private recenterer: Recenterer;
 
-    private isInUniversalArgumentMode = false;
-    private universalArgumentStr: string = "";
+    private isInPrefixArgumentMode = false;
+    private prefixArgumentStr: string = "";
 
     constructor(textEditor: TextEditor, killRing: KillRing | null = null) {
         this.textEditor = textEditor;
@@ -54,7 +54,7 @@ export class EmacsEmulator implements Disposable {
     // tslint:disable-next-line:max-line-length
     // Ref: https://github.com/Microsoft/vscode-extension-samples/blob/f9955406b4cad550fdfa891df23a84a2b344c3d8/vim-sample/src/extension.ts#L152
     public type(text: string) {
-        if (!this.isInUniversalArgumentMode) {
+        if (!this.isInPrefixArgumentMode) {
             // Simply delegate to the original behavior
             return vscode.commands.executeCommand("default:type", {
                 text,
@@ -63,16 +63,16 @@ export class EmacsEmulator implements Disposable {
 
         if (!isNaN(+text)) {
             // If `text` is a numeric charactor
-            this.universalArgumentStr += text;
+            this.prefixArgumentStr += text;
             return;
         }
 
-        const universalArgument = this.getUniversalArgument();
-        if (universalArgument === undefined) { return; }
+        const prefixArgument = this.getPrefixArgument();
+        if (prefixArgument === undefined) { return; }
 
-        this.exitUniversalArgumentMode();
+        this.exitPrefixArgumentMode();
         const promises = [];
-        for (let i = 0; i < universalArgument; ++i) {
+        for (let i = 0; i < prefixArgument; ++i) {
             const promise = vscode.commands.executeCommand("default:type", {
                 text,
             });
@@ -82,24 +82,24 @@ export class EmacsEmulator implements Disposable {
         return Promise.all(promises);
     }
 
-    public enterUniversalArgumentMode() {
-        this.isInUniversalArgumentMode = true;
-        this.universalArgumentStr = "";
+    public enterPrefixArgumentMode() {
+        this.isInPrefixArgumentMode = true;
+        this.prefixArgumentStr = "";
     }
 
-    public exitUniversalArgumentMode() {
-        this.isInUniversalArgumentMode = false;
-        this.universalArgumentStr = "";
+    public exitPrefixArgumentMode() {
+        this.isInPrefixArgumentMode = false;
+        this.prefixArgumentStr = "";
     }
 
-    public getUniversalArgument(): number | undefined {
-        if (!this.isInUniversalArgumentMode) { return undefined; }
+    public getPrefixArgument(): number | undefined {
+        if (!this.isInPrefixArgumentMode) { return undefined; }
 
-        const universalArgument = parseInt(this.universalArgumentStr, 10);
-        if (isNaN(universalArgument)) {
+        const prefixArgument = parseInt(this.prefixArgumentStr, 10);
+        if (isNaN(prefixArgument)) {
             return 4;
         }
-        return universalArgument;
+        return prefixArgument;
     }
 
     public cursorMove(commandName: cursorMoves) {
@@ -143,7 +143,7 @@ export class EmacsEmulator implements Disposable {
 
         this.killYanker.cancelKillAppend();
         this.recenterer.reset();
-        this.exitUniversalArgumentMode();
+        this.exitPrefixArgumentMode();
 
         MessageManager.showMessage("Quit");
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,8 +75,8 @@ export function activate(context: vscode.ExtensionContext) {
         (args) => vscode.commands.executeCommand("default:type", args),
     );
 
-    registerEmulatorCommand("emacs-mcx.universalArgument", (emulator) => {
-        emulator.enterUniversalArgumentMode();
+    registerEmulatorCommand("emacs-mcx.prefixArgument", (emulator) => {
+        emulator.enterPrefixArgumentMode();
     });
 
     registerEmulatorCommand("emacs-mcx.killLine", (emulator) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,8 +75,8 @@ export function activate(context: vscode.ExtensionContext) {
         (args) => vscode.commands.executeCommand("default:type", args),
     );
 
-    registerEmulatorCommand("emacs-mcx.prefixArgument", (emulator) => {
-        emulator.enterPrefixArgumentMode();
+    registerEmulatorCommand("emacs-mcx.universalArgument", (emulator) => {
+        emulator.universalArgument();
     });
 
     registerEmulatorCommand("emacs-mcx.killLine", (emulator) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,14 +44,18 @@ export function activate(context: vscode.ExtensionContext) {
     function registerEmulatorCommand(
         commandName: string,
         callback: (emulator: EmacsEmulator, ...args: any[]) => any,
+        onNoEmulator?: (...args: any[]) => any,
     ) {
-        const disposable = vscode.commands.registerCommand(commandName, () => {
+        const disposable = vscode.commands.registerCommand(commandName, (...args) => {
             const emulator = getAndUpdateEmulator();
             if (!emulator) {
+                if (typeof onNoEmulator === "function") {
+                    onNoEmulator(...args);
+                }
                 return;
             }
 
-            callback(emulator);
+            callback(emulator, ...args);
         });
         context.subscriptions.push(disposable);
     }
@@ -60,6 +64,19 @@ export function activate(context: vscode.ExtensionContext) {
         registerEmulatorCommand(`emacs-mcx.${commandName}`, (emulator) => {
             emulator.cursorMove(commandName);
         });
+    });
+
+    registerEmulatorCommand("type",
+        (emulator, args) => {
+            // Capture typing charactors for universal argument functionality.
+            // TODO: How to capture backspace?
+            emulator.type(args.text);
+        },
+        (args) => vscode.commands.executeCommand("default:type", args),
+    );
+
+    registerEmulatorCommand("emacs-mcx.universalArgument", (emulator) => {
+        emulator.enterUniversalArgumentMode();
     });
 
     registerEmulatorCommand("emacs-mcx.killLine", (emulator) => {

--- a/src/prefix-argument.ts
+++ b/src/prefix-argument.ts
@@ -1,0 +1,51 @@
+export class PrefixArgumentHandler {
+    private isInPrefixArgumentMode = false;
+    private isAcceptingPrefixArgument = false;
+    private cuCount = 0;  // How many C-u are input continuously
+    private prefixArgumentStr = "";  // Prefix argument string input after C-u
+
+    public handleType(text: string): boolean {
+        if (!this.isInPrefixArgumentMode) {
+            return false;
+        }
+
+        if (this.isAcceptingPrefixArgument && !isNaN(+text)) {
+            // If `text` is a numeric charactor
+            this.prefixArgumentStr += text;
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Emacs' ctrl-u
+     */
+    public universalArgument() {
+        if (this.isInPrefixArgumentMode && this.prefixArgumentStr.length > 0) {
+            this.isAcceptingPrefixArgument = false;
+        } else {
+            this.isInPrefixArgumentMode = true;
+            this.isAcceptingPrefixArgument = true;
+            this.cuCount++;
+            this.prefixArgumentStr = "";
+        }
+    }
+
+    public cancel() {
+        this.isInPrefixArgumentMode = false;
+        this.isAcceptingPrefixArgument = false;
+        this.cuCount = 0;
+        this.prefixArgumentStr = "";
+    }
+
+    public getPrefixArgument(): number | undefined {
+        if (!this.isInPrefixArgumentMode) { return undefined; }
+
+        const prefixArgument = parseInt(this.prefixArgumentStr, 10);
+        if (isNaN(prefixArgument)) {
+            return 4 ** this.cuCount;
+        }
+        return prefixArgument;
+    }
+}

--- a/src/test/prefix-argument.test.ts
+++ b/src/test/prefix-argument.test.ts
@@ -85,6 +85,54 @@ suite("Prefix argument (Universal argument: C-u)", () => {
 
             assertTextEqual(activeTextEditor, "aaaab");
         });
+
+        [2, 3].forEach((times) => {
+            test(`repeating charactor input with ${times} C-u`, async () => {
+                for (let i = 0; i < times; ++i) {
+                    emulator.enterPrefixArgumentMode();
+                }
+                await emulator.type("a");
+
+                assertTextEqual(activeTextEditor, "a".repeat(4 ** times));
+
+                // exitied from universal argument mode
+                await emulator.type("b");
+
+                assertTextEqual(activeTextEditor, "a".repeat(4 ** times) + "b");
+            });
+        });
+
+        test("c-u stops prefix argument input", async () => {
+            emulator.enterPrefixArgumentMode();
+            await emulator.type("1");
+            await emulator.type("2");
+            emulator.enterPrefixArgumentMode();
+            await emulator.type("3")
+
+            assertTextEqual(activeTextEditor, "333333333333");
+
+            // exitied from universal argument mode
+            await emulator.type("4");
+            await emulator.type("b");
+
+            assertTextEqual(activeTextEditor, "3333333333334b");
+        });
+
+        test("numerical input cancels previous repeated c-u", async () => {
+            emulator.enterPrefixArgumentMode();
+            emulator.enterPrefixArgumentMode();
+            emulator.enterPrefixArgumentMode();
+            await emulator.type("3");
+            await emulator.type("a");
+
+            assertTextEqual(activeTextEditor, "aaa");
+
+            // exitied from universal argument mode
+            await emulator.type("3");
+            await emulator.type("b");
+
+            assertTextEqual(activeTextEditor, "aaa3b");
+        });
     });
 
     suite("repeating EmacsEmulator's command (cursorMove (cursorRight)) with prefix command", () => {
@@ -225,6 +273,79 @@ suite("Prefix argument (Universal argument: C-u)", () => {
             assert.ok(
                 activeTextEditor.selections[0].isEqual(
                     new Range(new Position(0, 5), new Position(0, 5)),
+                ),
+            );
+        });
+
+        test("repeating charactor input with 2 C-u", async () => {
+            emulator.enterPrefixArgumentMode();
+            emulator.enterPrefixArgumentMode();
+            await emulator.cursorMove("cursorRight");
+
+            assert.equal(activeTextEditor.selections.length, 1);
+            assert.ok(
+                activeTextEditor.selections[0].isEqual(
+                    new Range(new Position(0, 16), new Position(0, 16)),
+                ),
+            );
+
+            // exitied from universal argument mode
+            await emulator.cursorMove("cursorRight");
+
+            assert.equal(activeTextEditor.selections.length, 1);
+            assert.ok(
+                activeTextEditor.selections[0].isEqual(
+                    new Range(new Position(0, 17), new Position(0, 17)),
+                ),
+            );
+        });
+
+        test("c-u stops prefix argument input", async () => {
+            emulator.enterPrefixArgumentMode();
+            await emulator.type("1");
+            await emulator.type("2");
+            emulator.enterPrefixArgumentMode();
+            await emulator.cursorMove("cursorRight");
+
+            assert.equal(activeTextEditor.selections.length, 1);
+            assert.ok(
+                activeTextEditor.selections[0].isEqual(
+                    new Range(new Position(0, 12), new Position(0, 12)),
+                ),
+            );
+
+            // exitied from universal argument mode
+            await emulator.cursorMove("cursorRight");
+
+            assert.equal(activeTextEditor.selections.length, 1);
+            assert.ok(
+                activeTextEditor.selections[0].isEqual(
+                    new Range(new Position(0, 13), new Position(0, 13)),
+                ),
+            );
+        });
+
+        test("numerical input cancels previous repeated c-u", async () => {
+            emulator.enterPrefixArgumentMode();
+            emulator.enterPrefixArgumentMode();
+            emulator.enterPrefixArgumentMode();
+            await emulator.type("3");
+            await emulator.cursorMove("cursorRight");
+
+            assert.equal(activeTextEditor.selections.length, 1);
+            assert.ok(
+                activeTextEditor.selections[0].isEqual(
+                    new Range(new Position(0, 3), new Position(0, 3)),
+                ),
+            );
+
+            // exitied from universal argument mode
+            await emulator.cursorMove("cursorRight");
+
+            assert.equal(activeTextEditor.selections.length, 1);
+            assert.ok(
+                activeTextEditor.selections[0].isEqual(
+                    new Range(new Position(0, 4), new Position(0, 4)),
                 ),
             );
         });

--- a/src/test/prefix-argument.test.ts
+++ b/src/test/prefix-argument.test.ts
@@ -16,7 +16,7 @@ suite("Prefix argument (Universal argument: C-u)", () => {
         teardown(cleanUpWorkspace);
 
         test("repeating charactor input for the given argument", async () => {
-            emulator.enterPrefixArgumentMode();
+            emulator.universalArgument();
             await emulator.type("2");
             await emulator.type("a");
 
@@ -30,7 +30,7 @@ suite("Prefix argument (Universal argument: C-u)", () => {
         });
 
         test("repeating charactor input for the given argument 0", async () => {
-            emulator.enterPrefixArgumentMode();
+            emulator.universalArgument();
 
             await emulator.type("0");
             await emulator.type("a");
@@ -43,7 +43,7 @@ suite("Prefix argument (Universal argument: C-u)", () => {
         });
 
         test("repeating charactor input for the given argument prefixed by 0", async () => {
-            emulator.enterPrefixArgumentMode();
+            emulator.universalArgument();
             await emulator.type("0");
             await emulator.type("2");
             await emulator.type("a");
@@ -59,7 +59,7 @@ suite("Prefix argument (Universal argument: C-u)", () => {
         });
 
         test("repeating charactor input for the given argument with multiple digits", async () => {
-            emulator.enterPrefixArgumentMode();
+            emulator.universalArgument();
             await emulator.type("1");
             await emulator.type("2");
             await emulator.type("a");
@@ -75,7 +75,7 @@ suite("Prefix argument (Universal argument: C-u)", () => {
         });
 
         test("repeating charactor input with default argument (4)", async () => {
-            emulator.enterPrefixArgumentMode();
+            emulator.universalArgument();
             await emulator.type("a");
 
             assertTextEqual(activeTextEditor, "aaaa");
@@ -89,7 +89,7 @@ suite("Prefix argument (Universal argument: C-u)", () => {
         [2, 3].forEach((times) => {
             test(`repeating charactor input with ${times} C-u`, async () => {
                 for (let i = 0; i < times; ++i) {
-                    emulator.enterPrefixArgumentMode();
+                    emulator.universalArgument();
                 }
                 await emulator.type("a");
 
@@ -103,11 +103,11 @@ suite("Prefix argument (Universal argument: C-u)", () => {
         });
 
         test("c-u stops prefix argument input", async () => {
-            emulator.enterPrefixArgumentMode();
+            emulator.universalArgument();
             await emulator.type("1");
             await emulator.type("2");
-            emulator.enterPrefixArgumentMode();
-            await emulator.type("3")
+            emulator.universalArgument();
+            await emulator.type("3");
 
             assertTextEqual(activeTextEditor, "333333333333");
 
@@ -119,9 +119,9 @@ suite("Prefix argument (Universal argument: C-u)", () => {
         });
 
         test("numerical input cancels previous repeated c-u", async () => {
-            emulator.enterPrefixArgumentMode();
-            emulator.enterPrefixArgumentMode();
-            emulator.enterPrefixArgumentMode();
+            emulator.universalArgument();
+            emulator.universalArgument();
+            emulator.universalArgument();
             await emulator.type("3");
             await emulator.type("a");
 
@@ -146,7 +146,7 @@ suite("Prefix argument (Universal argument: C-u)", () => {
         test("repeating cursorMove for the given argument", async () => {
             setEmptyCursors(activeTextEditor, [0, 0]);
 
-            emulator.enterPrefixArgumentMode();
+            emulator.universalArgument();
             await emulator.type("3");
             await emulator.cursorMove("cursorRight");
 
@@ -173,7 +173,7 @@ suite("Prefix argument (Universal argument: C-u)", () => {
         test("repeating cursorMove for the given argument 0", async () => {
             setEmptyCursors(activeTextEditor, [0, 0]);
 
-            emulator.enterPrefixArgumentMode();
+            emulator.universalArgument();
             await emulator.type("0");
             await emulator.cursorMove("cursorRight");
 
@@ -200,7 +200,7 @@ suite("Prefix argument (Universal argument: C-u)", () => {
         test("repeating cursorMove for the given argument 0", async () => {
             setEmptyCursors(activeTextEditor, [0, 0]);
 
-            emulator.enterPrefixArgumentMode();
+            emulator.universalArgument();
             await emulator.type("0");
             await emulator.cursorMove("cursorRight");
 
@@ -227,7 +227,7 @@ suite("Prefix argument (Universal argument: C-u)", () => {
         test("repeating cursorMove for the given argument with multiple digits", async () => {
             setEmptyCursors(activeTextEditor, [0, 0]);
 
-            emulator.enterPrefixArgumentMode();
+            emulator.universalArgument();
             await emulator.type("1");
             await emulator.type("2");
             await emulator.cursorMove("cursorRight");
@@ -256,7 +256,7 @@ suite("Prefix argument (Universal argument: C-u)", () => {
         test("repeating cursorMove for the default argument (4)", async () => {
             setEmptyCursors(activeTextEditor, [0, 0]);
 
-            emulator.enterPrefixArgumentMode();
+            emulator.universalArgument();
             await emulator.cursorMove("cursorRight");
 
             assert.equal(activeTextEditor.selections.length, 1);
@@ -278,8 +278,8 @@ suite("Prefix argument (Universal argument: C-u)", () => {
         });
 
         test("repeating charactor input with 2 C-u", async () => {
-            emulator.enterPrefixArgumentMode();
-            emulator.enterPrefixArgumentMode();
+            emulator.universalArgument();
+            emulator.universalArgument();
             await emulator.cursorMove("cursorRight");
 
             assert.equal(activeTextEditor.selections.length, 1);
@@ -301,10 +301,10 @@ suite("Prefix argument (Universal argument: C-u)", () => {
         });
 
         test("c-u stops prefix argument input", async () => {
-            emulator.enterPrefixArgumentMode();
+            emulator.universalArgument();
             await emulator.type("1");
             await emulator.type("2");
-            emulator.enterPrefixArgumentMode();
+            emulator.universalArgument();
             await emulator.cursorMove("cursorRight");
 
             assert.equal(activeTextEditor.selections.length, 1);
@@ -326,9 +326,9 @@ suite("Prefix argument (Universal argument: C-u)", () => {
         });
 
         test("numerical input cancels previous repeated c-u", async () => {
-            emulator.enterPrefixArgumentMode();
-            emulator.enterPrefixArgumentMode();
-            emulator.enterPrefixArgumentMode();
+            emulator.universalArgument();
+            emulator.universalArgument();
+            emulator.universalArgument();
             await emulator.type("3");
             await emulator.cursorMove("cursorRight");
 
@@ -353,7 +353,7 @@ suite("Prefix argument (Universal argument: C-u)", () => {
         test("multicursor with given argument", async () => {
             setEmptyCursors(activeTextEditor, [0, 0], [1, 0]);
 
-            emulator.enterPrefixArgumentMode();
+            emulator.universalArgument();
             await emulator.type("3");
             await emulator.cursorMove("cursorRight");
 

--- a/src/test/prefix-argument.test.ts
+++ b/src/test/prefix-argument.test.ts
@@ -1,86 +1,269 @@
-import { TextEditor } from "vscode";
+import * as assert from "assert";
+import { Position, Range, TextEditor } from "vscode";
 import { EmacsEmulator } from "../emulator";
-import { assertTextEqual, cleanUpWorkspace, setupWorkspace } from "./utils";
+import { assertTextEqual, cleanUpWorkspace, setEmptyCursors, setupWorkspace } from "./utils";
 
-suite("Prefix argument", () => {
+suite("Prefix argument (Universal argument: C-u)", () => {
     let activeTextEditor: TextEditor;
     let emulator: EmacsEmulator;
 
-    setup(async () => {
-        activeTextEditor = await setupWorkspace();
-        emulator = new EmacsEmulator(activeTextEditor);
+    suite("repeating single character", () => {
+        setup(async () => {
+            activeTextEditor = await setupWorkspace();
+            emulator = new EmacsEmulator(activeTextEditor);
+        });
+
+        teardown(cleanUpWorkspace);
+
+        test("repeating charactor input for the given argument", async () => {
+            emulator.enterPrefixArgumentMode();
+            await emulator.type("2");
+            await emulator.type("a");
+
+            assertTextEqual(activeTextEditor, "aa");
+
+            // exitied from universal argument mode
+            await emulator.type("2");
+            await emulator.type("b");
+
+            assertTextEqual(activeTextEditor, "aa2b");
+        });
+
+        test("repeating charactor input for the given argument 0", async () => {
+            emulator.enterPrefixArgumentMode();
+
+            await emulator.type("0");
+            await emulator.type("a");
+            assertTextEqual(activeTextEditor, "");
+
+            // exitied from universal argument mode
+            await emulator.type("0");
+            await emulator.type("b");
+            assertTextEqual(activeTextEditor, "0b");
+        });
+
+        test("repeating charactor input for the given argument prefixed by 0", async () => {
+            emulator.enterPrefixArgumentMode();
+            await emulator.type("0");
+            await emulator.type("2");
+            await emulator.type("a");
+
+            assertTextEqual(activeTextEditor, "aa");
+
+            // exitied from universal argument mode
+            await emulator.type("0");
+            await emulator.type("2");
+            await emulator.type("b");
+
+            assertTextEqual(activeTextEditor, "aa02b");
+        });
+
+        test("repeating charactor input for the given argument with multiple digits", async () => {
+            emulator.enterPrefixArgumentMode();
+            await emulator.type("1");
+            await emulator.type("2");
+            await emulator.type("a");
+
+            assertTextEqual(activeTextEditor, "aaaaaaaaaaaa");
+
+            // exitied from universal argument mode
+            await emulator.type("1");
+            await emulator.type("2");
+            await emulator.type("b");
+
+            assertTextEqual(activeTextEditor, "aaaaaaaaaaaa12b");
+        });
+
+        test("repeating charactor input with default argument (4)", async () => {
+            emulator.enterPrefixArgumentMode();
+            await emulator.type("a");
+
+            assertTextEqual(activeTextEditor, "aaaa");
+
+            // exitied from universal argument mode
+            await emulator.type("b");
+
+            assertTextEqual(activeTextEditor, "aaaab");
+        });
     });
 
-    teardown(cleanUpWorkspace);
+    suite("repeating EmacsEmulator's command (cursorMove (cursorRight)) with prefix command", () => {
+        setup(async () => {
+            activeTextEditor = await setupWorkspace("abcdefghijklmnopqrst\nabcdefghijklmnopqrst");
+            emulator = new EmacsEmulator(activeTextEditor);
+        });
 
-    test("repeating charactor input for the given argument", async () => {
-        emulator.enterPrefixArgumentMode();
-        await emulator.type("2");
-        await emulator.type("a");
+        teardown(cleanUpWorkspace);
 
-        assertTextEqual(activeTextEditor, "aa");
+        test("repeating cursorMove for the given argument", async () => {
+            setEmptyCursors(activeTextEditor, [0, 0]);
 
-        // exitied from universal argument mode
-        await emulator.type("2");
-        await emulator.type("b");
+            emulator.enterPrefixArgumentMode();
+            await emulator.type("3");
+            await emulator.cursorMove("cursorRight");
 
-        assertTextEqual(activeTextEditor, "aa2b");
-    });
+            assert.equal(activeTextEditor.selections.length, 1);
+            assert.ok(
+                activeTextEditor.selections[0].isEqual(
+                    new Range(new Position(0, 3), new Position(0, 3)),
+                ),
+            );
 
-    test("repeating charactor input for the given argument 0", async () => {
-        emulator.enterPrefixArgumentMode();
+            // exitied from universal argument mode
+            await emulator.type("3");
+            await emulator.cursorMove("cursorRight");
 
-        await emulator.type("0");
-        await emulator.type("a");
-        assertTextEqual(activeTextEditor, "");
+            assertTextEqual(activeTextEditor, "abc3defghijklmnopqrst\nabcdefghijklmnopqrst");
+            assert.equal(activeTextEditor.selections.length, 1);
+            assert.ok(
+                activeTextEditor.selections[0].isEqual(
+                    new Range(new Position(0, 5), new Position(0, 5)),
+                ),
+            );
+        });
 
-        // exitied from universal argument mode
-        await emulator.type("0");
-        await emulator.type("b");
-        assertTextEqual(activeTextEditor, "0b");
-    });
+        test("repeating cursorMove for the given argument 0", async () => {
+            setEmptyCursors(activeTextEditor, [0, 0]);
 
-    test("repeating charactor input for the given argument prefixed by 0", async () => {
-        emulator.enterPrefixArgumentMode();
-        await emulator.type("0");
-        await emulator.type("2");
-        await emulator.type("a");
+            emulator.enterPrefixArgumentMode();
+            await emulator.type("0");
+            await emulator.cursorMove("cursorRight");
 
-        assertTextEqual(activeTextEditor, "aa");
+            assert.equal(activeTextEditor.selections.length, 1);
+            assert.ok(
+                activeTextEditor.selections[0].isEqual(
+                    new Range(new Position(0, 0), new Position(0, 0)),
+                ),
+            );
 
-        // exitied from universal argument mode
-        await emulator.type("0");
-        await emulator.type("2");
-        await emulator.type("b");
+            // exitied from universal argument mode
+            await emulator.type("0");
+            await emulator.cursorMove("cursorRight");
 
-        assertTextEqual(activeTextEditor, "aa02b");
-    });
+            assertTextEqual(activeTextEditor, "0abcdefghijklmnopqrst\nabcdefghijklmnopqrst");
+            assert.equal(activeTextEditor.selections.length, 1);
+            assert.ok(
+                activeTextEditor.selections[0].isEqual(
+                    new Range(new Position(0, 2), new Position(0, 2)),
+                ),
+            );
+        });
 
-    test("repeating charactor input for the given argument with multiple digits", async () => {
-        emulator.enterPrefixArgumentMode();
-        await emulator.type("1");
-        await emulator.type("2");
-        await emulator.type("a");
+        test("repeating cursorMove for the given argument 0", async () => {
+            setEmptyCursors(activeTextEditor, [0, 0]);
 
-        assertTextEqual(activeTextEditor, "aaaaaaaaaaaa");
+            emulator.enterPrefixArgumentMode();
+            await emulator.type("0");
+            await emulator.cursorMove("cursorRight");
 
-        // exitied from universal argument mode
-        await emulator.type("1");
-        await emulator.type("2");
-        await emulator.type("b");
+            assert.equal(activeTextEditor.selections.length, 1);
+            assert.ok(
+                activeTextEditor.selections[0].isEqual(
+                    new Range(new Position(0, 0), new Position(0, 0)),
+                ),
+            );
 
-        assertTextEqual(activeTextEditor, "aaaaaaaaaaaa12b");
-    });
+            // exitied from universal argument mode
+            await emulator.type("0");
+            await emulator.cursorMove("cursorRight");
 
-    test("repeating charactor input with default argument (4)", async () => {
-        emulator.enterPrefixArgumentMode();
-        await emulator.type("a");
+            assertTextEqual(activeTextEditor, "0abcdefghijklmnopqrst\nabcdefghijklmnopqrst");
+            assert.equal(activeTextEditor.selections.length, 1);
+            assert.ok(
+                activeTextEditor.selections[0].isEqual(
+                    new Range(new Position(0, 2), new Position(0, 2)),
+                ),
+            );
+        });
 
-        assertTextEqual(activeTextEditor, "aaaa");
+        test("repeating cursorMove for the given argument with multiple digits", async () => {
+            setEmptyCursors(activeTextEditor, [0, 0]);
 
-        // exitied from universal argument mode
-        await emulator.type("b");
+            emulator.enterPrefixArgumentMode();
+            await emulator.type("1");
+            await emulator.type("2");
+            await emulator.cursorMove("cursorRight");
 
-        assertTextEqual(activeTextEditor, "aaaab");
+            assert.equal(activeTextEditor.selections.length, 1);
+            assert.ok(
+                activeTextEditor.selections[0].isEqual(
+                    new Range(new Position(0, 12), new Position(0, 12)),
+                ),
+            );
+
+            // exitied from universal argument mode
+            await emulator.type("1");
+            await emulator.type("2");
+            await emulator.cursorMove("cursorRight");
+
+            assertTextEqual(activeTextEditor, "abcdefghijkl12mnopqrst\nabcdefghijklmnopqrst");
+            assert.equal(activeTextEditor.selections.length, 1);
+            assert.ok(
+                activeTextEditor.selections[0].isEqual(
+                    new Range(new Position(0, 15), new Position(0, 15)),
+                ),
+            );
+        });
+
+        test("repeating cursorMove for the default argument (4)", async () => {
+            setEmptyCursors(activeTextEditor, [0, 0]);
+
+            emulator.enterPrefixArgumentMode();
+            await emulator.cursorMove("cursorRight");
+
+            assert.equal(activeTextEditor.selections.length, 1);
+            assert.ok(
+                activeTextEditor.selections[0].isEqual(
+                    new Range(new Position(0, 4), new Position(0, 4)),
+                ),
+            );
+
+            // exitied from universal argument mode
+            await emulator.cursorMove("cursorRight");
+
+            assert.equal(activeTextEditor.selections.length, 1);
+            assert.ok(
+                activeTextEditor.selections[0].isEqual(
+                    new Range(new Position(0, 5), new Position(0, 5)),
+                ),
+            );
+        });
+
+        test("multicursor with given argument", async () => {
+            setEmptyCursors(activeTextEditor, [0, 0], [1, 0]);
+
+            emulator.enterPrefixArgumentMode();
+            await emulator.type("3");
+            await emulator.cursorMove("cursorRight");
+
+            assert.equal(activeTextEditor.selections.length, 2);
+            assert.ok(
+                activeTextEditor.selections[0].isEqual(
+                    new Range(new Position(0, 3), new Position(0, 3)),
+                ),
+            );
+            assert.ok(
+                activeTextEditor.selections[1].isEqual(
+                    new Range(new Position(1, 3), new Position(1, 3)),
+                ),
+            );
+
+            // exitied from universal argument mode
+            await emulator.type("3");
+            await emulator.cursorMove("cursorRight");
+
+            assertTextEqual(activeTextEditor, "abc3defghijklmnopqrst\nabc3defghijklmnopqrst");
+            assert.equal(activeTextEditor.selections.length, 2);
+            assert.ok(
+                activeTextEditor.selections[0].isEqual(
+                    new Range(new Position(0, 5), new Position(0, 5)),
+                ),
+            );
+            assert.ok(
+                activeTextEditor.selections[1].isEqual(
+                    new Range(new Position(1, 5), new Position(1, 5)),
+                ),
+            );
+        });
     });
 });

--- a/src/test/prefix-argument.test.ts
+++ b/src/test/prefix-argument.test.ts
@@ -2,7 +2,7 @@ import { TextEditor } from "vscode";
 import { EmacsEmulator } from "../emulator";
 import { assertTextEqual, cleanUpWorkspace, setupWorkspace } from "./utils";
 
-suite("Universal argument", () => {
+suite("Prefix argument", () => {
     let activeTextEditor: TextEditor;
     let emulator: EmacsEmulator;
 
@@ -14,7 +14,7 @@ suite("Universal argument", () => {
     teardown(cleanUpWorkspace);
 
     test("repeating charactor input for the given argument", async () => {
-        emulator.enterUniversalArgumentMode();
+        emulator.enterPrefixArgumentMode();
         await emulator.type("2");
         await emulator.type("a");
 
@@ -28,7 +28,7 @@ suite("Universal argument", () => {
     });
 
     test("repeating charactor input for the given argument 0", async () => {
-        emulator.enterUniversalArgumentMode();
+        emulator.enterPrefixArgumentMode();
 
         await emulator.type("0");
         await emulator.type("a");
@@ -41,7 +41,7 @@ suite("Universal argument", () => {
     });
 
     test("repeating charactor input for the given argument prefixed by 0", async () => {
-        emulator.enterUniversalArgumentMode();
+        emulator.enterPrefixArgumentMode();
         await emulator.type("0");
         await emulator.type("2");
         await emulator.type("a");
@@ -57,7 +57,7 @@ suite("Universal argument", () => {
     });
 
     test("repeating charactor input for the given argument with multiple digits", async () => {
-        emulator.enterUniversalArgumentMode();
+        emulator.enterPrefixArgumentMode();
         await emulator.type("1");
         await emulator.type("2");
         await emulator.type("a");
@@ -73,7 +73,7 @@ suite("Universal argument", () => {
     });
 
     test("repeating charactor input with default argument (4)", async () => {
-        emulator.enterUniversalArgumentMode();
+        emulator.enterPrefixArgumentMode();
         await emulator.type("a");
 
         assertTextEqual(activeTextEditor, "aaaa");

--- a/src/test/universal-argument.test.ts
+++ b/src/test/universal-argument.test.ts
@@ -1,0 +1,86 @@
+import { TextEditor } from "vscode";
+import { EmacsEmulator } from "../emulator";
+import { assertTextEqual, cleanUpWorkspace, setupWorkspace } from "./utils";
+
+suite("Universal argument", () => {
+    let activeTextEditor: TextEditor;
+    let emulator: EmacsEmulator;
+
+    setup(async () => {
+        activeTextEditor = await setupWorkspace();
+        emulator = new EmacsEmulator(activeTextEditor);
+    });
+
+    teardown(cleanUpWorkspace);
+
+    test("repeating charactor input for the given argument", async () => {
+        emulator.enterUniversalArgumentMode();
+        await emulator.type("2");
+        await emulator.type("a");
+
+        assertTextEqual(activeTextEditor, "aa");
+
+        // exitied from universal argument mode
+        await emulator.type("2");
+        await emulator.type("b");
+
+        assertTextEqual(activeTextEditor, "aa2b");
+    });
+
+    test("repeating charactor input for the given argument 0", async () => {
+        emulator.enterUniversalArgumentMode();
+
+        await emulator.type("0");
+        await emulator.type("a");
+        assertTextEqual(activeTextEditor, "");
+
+        // exitied from universal argument mode
+        await emulator.type("0");
+        await emulator.type("b");
+        assertTextEqual(activeTextEditor, "0b");
+    });
+
+    test("repeating charactor input for the given argument prefixed by 0", async () => {
+        emulator.enterUniversalArgumentMode();
+        await emulator.type("0");
+        await emulator.type("2");
+        await emulator.type("a");
+
+        assertTextEqual(activeTextEditor, "aa");
+
+        // exitied from universal argument mode
+        await emulator.type("0");
+        await emulator.type("2");
+        await emulator.type("b");
+
+        assertTextEqual(activeTextEditor, "aa02b");
+    });
+
+    test("repeating charactor input for the given argument with multiple digits", async () => {
+        emulator.enterUniversalArgumentMode();
+        await emulator.type("1");
+        await emulator.type("2");
+        await emulator.type("a");
+
+        assertTextEqual(activeTextEditor, "aaaaaaaaaaaa");
+
+        // exitied from universal argument mode
+        await emulator.type("1");
+        await emulator.type("2");
+        await emulator.type("b");
+
+        assertTextEqual(activeTextEditor, "aaaaaaaaaaaa12b");
+    });
+
+    test("repeating charactor input with default argument (4)", async () => {
+        emulator.enterUniversalArgumentMode();
+        await emulator.type("a");
+
+        assertTextEqual(activeTextEditor, "aaaa");
+
+        // exitied from universal argument mode
+        await emulator.type("b");
+
+        assertTextEqual(activeTextEditor, "aaaab");
+    });
+});


### PR DESCRIPTION
#59 

- [x] Repeating single character
- [x] Repeating commands defined by this extension
- [x] Multiple `C-u` (`C-u C-u a` results in 16 `a` s)