### PR TITLE
Reveal selection after forwardSexp/backwardSexp

### DIFF
--- a/src/paredit.ts
+++ b/src/paredit.ts
@@ -1,5 +1,5 @@
 import * as paredit from "paredit.js";
-import { Selection } from "vscode";
+import { Selection, TextEditorRevealType } from "vscode";
 import { EmacsEmulator } from "./emulator";
 
 export class Paredit {
@@ -37,5 +37,6 @@ export class Paredit {
         });
 
         textEditor.selections = newSelections;
+        textEditor.revealRange(textEditor.selection, TextEditorRevealType.InCenterIfOutsideViewport);
     }
 }


### PR DESCRIPTION
With Awesome Emacs Keymap, the cursor may sometims move outside the viewport  after using forwardSexp/backwardSexp,if the sexp is very large.

On orignal Emacs, the cursor always reside in the viewport.

This pull request reveals the cursor after forwardSexp/backwardSexp.