### PR TITLE
Update prefix argument to show message

### DIFF
--- a/src/prefix-argument.ts
+++ b/src/prefix-argument.ts
@@ -1,3 +1,5 @@
+import { MessageManager } from "./message";
+
 export class PrefixArgumentHandler {
     private isInPrefixArgumentMode = false;
     private isAcceptingPrefixArgument = false;
@@ -12,6 +14,7 @@ export class PrefixArgumentHandler {
         if (this.isAcceptingPrefixArgument && !isNaN(+text)) {
             // If `text` is a numeric charactor
             this.prefixArgumentStr += text;
+            MessageManager.showMessage(`C-u ${this.prefixArgumentStr}-`);
             return true;
         }
 


### PR DESCRIPTION
Show message representing the prefix argument input
For example:

1. `C-u`
<img width="237" alt="2019-02-22 0 36 04" src="https://user-images.githubusercontent.com/3135397/53180892-da98e600-3639-11e9-9314-d960d2492ac8.png">
(Nothing is shown)

2. `C-u 1`
<img width="244" alt="2019-02-22 0 35 15" src="https://user-images.githubusercontent.com/3135397/53180923-e8e70200-3639-11e9-89b3-7be5f3894274.png">

3. `C-u 1 2`
<img width="239" alt="2019-02-22 0 35 20" src="https://user-images.githubusercontent.com/3135397/53180941-f13f3d00-3639-11e9-819a-91666683945c.png">

4. `C-u 1 2 C-k`
<img width="237" alt="2019-02-22 0 36 04" src="https://user-images.githubusercontent.com/3135397/53180965-01efb300-363a-11e9-804e-54b95b808896.png">
(The message disappears as the specified command (`C-k` in this example) is executed with the specified prefix argument (12 in this example))
