### PR TITLE
use cursorMove for MoveBeginningOfLine

### DIFF
--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -88,14 +88,20 @@ export class MoveBeginningOfLine extends EmacsCommand {
 
     public execute(textEditor: TextEditor, isInMarkMode: boolean, prefixArgument: number | undefined) {
         if (prefixArgument === undefined || prefixArgument === 1) {
-            return vscode.commands.executeCommand(isInMarkMode ? "cursorHomeSelect" : "cursorHome");
+            return vscode.commands.executeCommand("cursorMove", {
+                to: "wrappedLineStart",
+                select: isInMarkMode,
+            })
         } else if (prefixArgument > 1) {
             return vscode.commands.executeCommand("cursorMove", {
                 to: "down",
                 by: "line",
                 value: prefixArgument - 1,
                 isInMarkMode,
-            }).then(() => vscode.commands.executeCommand(isInMarkMode ? "cursorHomeSelect" : "cursorHome"));
+            }).then(() => vscode.commands.executeCommand("cursorMove", {
+                to: "wrappedLineStart",
+                select: isInMarkMode,
+            }));
         }
     }
 }


### PR DESCRIPTION
Use `cursorMove` with `wrappedLineStart` to move the cursor to the beginning of the line, not the first non-whitespace character in the line.  This matches better with what Emacs does by default.

Fixes #113