### PR TITLE
add BlockUpCommand and BlockDownCommand

### DIFF
--- a/package.json
+++ b/package.json
@@ -893,8 +893,28 @@
 										"emacs-mcx.forwardChar",
 										"emacs-mcx.nextLine"
 								]
+						},
+						{
+								"key": "ctrl+up",
+								"command": "emacs-mcx.blockUpCommand",
+								"when": "editorTextFocus"
+						},
+						{
+								"key": "alt+shift+[",
+								"command": "emacs-mcx.blockUpCommand",
+								"when": "editorTextFocus"
+						},
+						{
+								"key": "ctrl+down",
+								"command": "emacs-mcx.blockDownCommand",
+								"when": "editorTextFocus"
+						},
+						{
+								"key": "alt+shift+]",
+								"command": "emacs-mcx.blockDownCommand",
+								"when": "editorTextFocus"
 						}
-				]
+			]
 		},
 		"scripts": {
 				"vscode:prepublish": "yarn run compile",

--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -9,6 +9,7 @@ export const moveCommandIds = [
     "forwardChar", "backwardChar", "nextLine", "previousLine",
     "moveBeginningOfLine", "moveEndOfLine", "forwardWord", "backwardWord",
     "beginningOfBuffer", "endOfBuffer", "scrollUpCommand", "scrollDownCommand",
+    "blockUpCommand", "blockDownCommand"
 ];
 
 export class ForwardChar extends EmacsCommand {
@@ -174,5 +175,25 @@ export class ScrollDownCommand extends EmacsCommand {
         const repeat = prefixArgument === undefined ? 1 : prefixArgument;
         return createParallel(repeat, () =>
             vscode.commands.executeCommand(isInMarkMode ? "cursorPageUpSelect" : "cursorPageUp"));
+    }
+}
+
+export class BlockUpCommand extends EmacsCommand {
+    public readonly id = "blockUpCommand";
+
+    public execute(textEditor: TextEditor, isInMarkMode: boolean, prefixArgument: number | undefined) {
+        const repeat = prefixArgument === undefined ? 1 : prefixArgument;
+        return createParallel(repeat, () =>
+            vscode.commands.executeCommand(isInMarkMode ? "block-travel.selectUp" : "block-travel.jumpUp"));
+    }
+}
+
+export class BlockDownCommand extends EmacsCommand {
+    public readonly id = "blockDownCommand";
+
+    public execute(textEditor: TextEditor, isInMarkMode: boolean, prefixArgument: number | undefined) {
+        const repeat = prefixArgument === undefined ? 1 : prefixArgument;
+        return createParallel(repeat, () =>
+            vscode.commands.executeCommand(isInMarkMode ? "block-travel.selectDown" : "block-travel.jumpDown"));
     }
 }

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -68,6 +68,8 @@ export class EmacsEmulator implements Disposable, IEmacsCommandRunner, IMarkMode
         this.commandRegistry.register(new MoveCommands.EndOfBuffer(this.afterCommand, this));
         this.commandRegistry.register(new MoveCommands.ScrollUpCommand(this.afterCommand, this));
         this.commandRegistry.register(new MoveCommands.ScrollDownCommand(this.afterCommand, this));
+        this.commandRegistry.register(new MoveCommands.BlockUpCommand(this.afterCommand, this));
+        this.commandRegistry.register(new MoveCommands.BlockDownCommand(this.afterCommand, this));
         this.commandRegistry.register(new EditCommands.DeleteBackwardChar(this.afterCommand, this));
         this.commandRegistry.register(new EditCommands.DeleteForwardChar(this.afterCommand, this));
         this.commandRegistry.register(new EditCommands.NewLine(this.afterCommand, this));


### PR DESCRIPTION
Bind them to C-Up and M-{ and C-Down and M-}, respectively.
This allows selections and prefix argument paragraph jumping to
work.

Fixes #114