### PR TITLE
place cursors at top/botton of viewport on scroll commands

### DIFF
--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -170,7 +170,16 @@ export class ScrollUpCommand extends EmacsCommand {
         const repeat = prefixArgument === undefined ? 1 : prefixArgument;
 
         if (repeat === 1) {
-            return vscode.commands.executeCommand(isInMarkMode ? "cursorPageDownSelect" : "cursorPageDown");
+            return vscode.commands.executeCommand("editorScroll", {
+                to: "down",
+                by: "page",
+            }).then(() => vscode.commands.executeCommand("cursorMove", {
+                to: "viewPortTop",
+                select: isInMarkMode,
+            })).then(() => vscode.commands.executeCommand("cursorMove", {
+                to: "wrappedLineStart",
+                select: isInMarkMode,
+            }));
         }
 
         return vscode.commands.executeCommand(
@@ -194,7 +203,16 @@ export class ScrollDownCommand extends EmacsCommand {
         const repeat = prefixArgument === undefined ? 1 : prefixArgument;
 
         if (repeat === 1) {
-            return vscode.commands.executeCommand(isInMarkMode ? "cursorPageUpSelect" : "cursorPageUp");
+            return vscode.commands.executeCommand("editorScroll", {
+                to: "up",
+                by: "page",
+            }).then(() => vscode.commands.executeCommand("cursorMove", {
+                to: "viewPortBottom",
+                select: isInMarkMode,
+            })).then(() => vscode.commands.executeCommand("cursorMove", {
+                to: "wrappedLineStart",
+                select: isInMarkMode,
+            }));
         }
 
         return vscode.commands.executeCommand(


### PR DESCRIPTION
To more closely match the Emacs behavior, when scrolling down by a page
with C-v, place the cursor at the top of the viewport in the leftmost
column.  When scrolling up by a page with M-v, place the cursor at the
bottom of the viewport in the leftmost column.