### PR TITLE
create new "emacs-mcx.find" command for resuming incremental search

### DIFF
--- a/package.json
+++ b/package.json
@@ -435,7 +435,7 @@
 			},
 			{
 				"key": "ctrl+s",
-				"command": "actions.find",
+				"command": "emacs-mcx.find",
 				"when": "!findWidgetVisible"
 			},
 			{

--- a/src/commands/find.ts
+++ b/src/commands/find.ts
@@ -1,0 +1,12 @@
+import * as vscode from "vscode";
+import { TextEditor } from "vscode";
+import { EmacsCommand } from ".";
+
+export class Find extends EmacsCommand {
+  public readonly id = "find";
+
+  public execute(textEditor: TextEditor, isInMarkMode: boolean, prefixArgument: number | undefined) {
+    const nextMatchFindActionFunc = () => vscode.commands.executeCommand<void>("editor.action.nextMatchFindAction");
+    return vscode.commands.executeCommand("actions.find").then(nextMatchFindActionFunc);
+  }
+}

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -5,6 +5,7 @@ import { AddSelectionToNextFindMatch, AddSelectionToPreviousFindMatch } from "./
 import * as CaseCommands from "./commands/case";
 import { DeleteBlankLines } from "./commands/delete-blank-lines";
 import * as EditCommands from "./commands/edit";
+import * as FindCommands from "./commands/find";
 import * as KillCommands from "./commands/kill";
 import * as MoveCommands from "./commands/move";
 import * as PareditCommands from "./commands/paredit";
@@ -68,6 +69,7 @@ export class EmacsEmulator implements Disposable, IEmacsCommandRunner, IMarkMode
     this.commandRegistry.register(new EditCommands.DeleteBackwardChar(this.afterCommand, this));
     this.commandRegistry.register(new EditCommands.DeleteForwardChar(this.afterCommand, this));
     this.commandRegistry.register(new EditCommands.NewLine(this.afterCommand, this));
+    this.commandRegistry.register(new FindCommands.Find(this.afterCommand, this));
     this.commandRegistry.register(new DeleteBlankLines(this.afterCommand, this));
 
     this.commandRegistry.register(new PareditCommands.ForwardSexp(this.afterCommand, this));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,6 +88,10 @@ export function activate(context: vscode.ExtensionContext) {
     });
   });
 
+  registerEmulatorCommand("emacs-mcx.find", emulator => {
+    emulator.runCommand("find");
+  });
+
   registerEmulatorCommand("emacs-mcx.deleteBackwardChar", emulator => {
     emulator.runCommand("deleteBackwardChar");
   });


### PR DESCRIPTION
In emacs, C-s resumes a previous incremental search.  In VSCode this
requires two presses.  This new find command emulates the Emacs
behavior.

Fixes #108