### PR TITLE
Fix some behaviors to follow to original emacs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Mainly, almost all keybinding settings are derived from [vscode-emacs-friendly b
 | `C-s` | Search forward |
 | `C-r` | Search backward |
 | `M-S-5` (`M-%` with US keyboard) | Replace |
-| `C-Enter` | Replace One Match (In replace dialog) |
 | `C-M-n` | Add selection to next find match |
 | `C-M-p` | Add selection to previous find match |
 

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
 				"when": "editorFocus && findWidgetVisible",
 				"args": [
 					"closeFindWidget",
-					"emacs-mcx.backwardChar",
+					"emacs-mcx.forwardChar",
 					"emacs-mcx.backwardChar"
 				]
 			},
@@ -146,7 +146,7 @@
 				"when": "editorFocus && findWidgetVisible",
 				"args": [
 					"closeFindWidget",
-					"emacs-mcx.backwardChar",
+					"emacs-mcx.forwardChar",
 					"emacs-mcx.backwardChar"
 				]
 			},

--- a/package.json
+++ b/package.json
@@ -469,11 +469,6 @@
 				"when": "editorFocus"
 			},
 			{
-				"key": "ctrl+enter",
-				"command": "editor.action.replaceOne",
-				"when": "editorFocus && findWidgetVisible"
-			},
-			{
 				"key": "ctrl+alt+n",
 				"command": "emacs-mcx.addSelectionToNextFindMatch",
 				"when": "editorFocus"

--- a/src/commands/recenter.ts
+++ b/src/commands/recenter.ts
@@ -1,7 +1,6 @@
 import * as vscode from "vscode";
 import { TextEditor, TextEditorRevealType } from "vscode";
 import { EmacsCommand, IEmacsCommandInterrupted } from ".";
-import { Configuration } from "../configuration/configuration";
 
 enum RecenterPosition {
   Middle,
@@ -15,38 +14,34 @@ export class RecenterTopBottom extends EmacsCommand implements IEmacsCommandInte
   private recenterPosition: RecenterPosition = RecenterPosition.Middle;
 
   public execute(textEditor: TextEditor, isInMarkMode: boolean, prefixArgument: number | undefined) {
-    if (Configuration.instance.strictEmacsMove) {
-      textEditor.revealRange(textEditor.selection, TextEditorRevealType.InCenter);
-    } else {
-      switch (this.recenterPosition) {
-        case RecenterPosition.Middle: {
-          textEditor.revealRange(textEditor.selection, TextEditorRevealType.InCenter);
-          this.recenterPosition = RecenterPosition.Top;
-          break;
-        }
-        case RecenterPosition.Top: {
-          textEditor.revealRange(textEditor.selection, TextEditorRevealType.AtTop);
-          this.recenterPosition = RecenterPosition.Bottom;
-          break;
-        }
-        case RecenterPosition.Bottom: {
-          // TextEditor.revealRange does not supprt to set the cursor at the bottom of window.
-          // Therefore, the number of lines to scroll is calculated here.
-          const current = textEditor.selection.active.line;
-          const visibleTop = textEditor.visibleRanges[0].start.line;
-          const visibleBottom = textEditor.visibleRanges[0].end.line;
-          const visibleHeight = visibleBottom - visibleTop;
+    switch (this.recenterPosition) {
+      case RecenterPosition.Middle: {
+        textEditor.revealRange(textEditor.selection, TextEditorRevealType.InCenter);
+        this.recenterPosition = RecenterPosition.Top;
+        break;
+      }
+      case RecenterPosition.Top: {
+        textEditor.revealRange(textEditor.selection, TextEditorRevealType.AtTop);
+        this.recenterPosition = RecenterPosition.Bottom;
+        break;
+      }
+      case RecenterPosition.Bottom: {
+        // TextEditor.revealRange does not supprt to set the cursor at the bottom of window.
+        // Therefore, the number of lines to scroll is calculated here.
+        const current = textEditor.selection.active.line;
+        const visibleTop = textEditor.visibleRanges[0].start.line;
+        const visibleBottom = textEditor.visibleRanges[0].end.line;
+        const visibleHeight = visibleBottom - visibleTop;
 
-          const nextVisibleTop = Math.max(current - visibleHeight, 1);
+        const nextVisibleTop = Math.max(current - visibleHeight, 1);
 
-          // Scroll so that `nextVisibleTop` is the top of window
-          const p = new vscode.Position(nextVisibleTop, 0);
-          const r = new vscode.Range(p, p);
-          textEditor.revealRange(r);
+        // Scroll so that `nextVisibleTop` is the top of window
+        const p = new vscode.Position(nextVisibleTop, 0);
+        const r = new vscode.Range(p, p);
+        textEditor.revealRange(r);
 
-          this.recenterPosition = RecenterPosition.Middle;
-          break;
-        }
+        this.recenterPosition = RecenterPosition.Middle;
+        break;
       }
     }
   }

--- a/src/commands/recenter.ts
+++ b/src/commands/recenter.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { TextEditor, TextEditorRevealType } from "vscode";
 import { EmacsCommand, IEmacsCommandInterrupted } from ".";
+import { Configuration } from "../configuration/configuration";
 
 enum RecenterPosition {
   Middle,
@@ -14,34 +15,38 @@ export class RecenterTopBottom extends EmacsCommand implements IEmacsCommandInte
   private recenterPosition: RecenterPosition = RecenterPosition.Middle;
 
   public execute(textEditor: TextEditor, isInMarkMode: boolean, prefixArgument: number | undefined) {
-    switch (this.recenterPosition) {
-      case RecenterPosition.Middle: {
-        textEditor.revealRange(textEditor.selection, TextEditorRevealType.InCenter);
-        this.recenterPosition = RecenterPosition.Top;
-        break;
-      }
-      case RecenterPosition.Top: {
-        textEditor.revealRange(textEditor.selection, TextEditorRevealType.AtTop);
-        this.recenterPosition = RecenterPosition.Bottom;
-        break;
-      }
-      case RecenterPosition.Bottom: {
-        // TextEditor.revealRange does not supprt to set the cursor at the bottom of window.
-        // Therefore, the number of lines to scroll is calculated here.
-        const current = textEditor.selection.active.line;
-        const visibleTop = textEditor.visibleRanges[0].start.line;
-        const visibleBottom = textEditor.visibleRanges[0].end.line;
-        const visibleHeight = visibleBottom - visibleTop;
+    if (Configuration.instance.strictEmacsMove) {
+      textEditor.revealRange(textEditor.selection, TextEditorRevealType.InCenter);
+    } else {
+      switch (this.recenterPosition) {
+        case RecenterPosition.Middle: {
+          textEditor.revealRange(textEditor.selection, TextEditorRevealType.InCenter);
+          this.recenterPosition = RecenterPosition.Top;
+          break;
+        }
+        case RecenterPosition.Top: {
+          textEditor.revealRange(textEditor.selection, TextEditorRevealType.AtTop);
+          this.recenterPosition = RecenterPosition.Bottom;
+          break;
+        }
+        case RecenterPosition.Bottom: {
+          // TextEditor.revealRange does not supprt to set the cursor at the bottom of window.
+          // Therefore, the number of lines to scroll is calculated here.
+          const current = textEditor.selection.active.line;
+          const visibleTop = textEditor.visibleRanges[0].start.line;
+          const visibleBottom = textEditor.visibleRanges[0].end.line;
+          const visibleHeight = visibleBottom - visibleTop;
 
-        const nextVisibleTop = Math.max(current - visibleHeight, 1);
+          const nextVisibleTop = Math.max(current - visibleHeight, 1);
 
-        // Scroll so that `nextVisibleTop` is the top of window
-        const p = new vscode.Position(nextVisibleTop, 0);
-        const r = new vscode.Range(p, p);
-        textEditor.revealRange(r);
+          // Scroll so that `nextVisibleTop` is the top of window
+          const p = new vscode.Position(nextVisibleTop, 0);
+          const r = new vscode.Range(p, p);
+          textEditor.revealRange(r);
 
-        this.recenterPosition = RecenterPosition.Middle;
-        break;
+          this.recenterPosition = RecenterPosition.Middle;
+          break;
+        }
       }
     }
   }


### PR DESCRIPTION
- Fix backward-char (C-b) cursor move while the search widget is displayed.
- I found that C-Enter in the replace widget (replace one) doesn't work well. So I have removed the binding tentatively.
  - It inserts the return code in the replace string contrary to the expectation.
  - Instead of C-Enter, Enter (VSCode's original binding) works as "replace one".
- The original emacs's behavior of "recenter" is different from the current one. I have fixed it when strictEmacsMove is enabled.