### PR TITLE
Create useMetaPrefixMacCmd config

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ The only exception is the commands which begin with `M-g` (`M-g g`, `M-g n`, `M-
 It is because VSCode can handle only up to two key strokes as the key bindings.
 So, as the special case, `Escape g` works as follows.
 
+### `emacs-mcx.useMetaPrefixMacCmd`
+If set to true, Command (⌘) key works as the Meta prefix like original emacs.
+This option only works on macOS.
+
+
 |Command | Desc |
 |--------|------|
 | `Escape g` | Jump to line (command palette) |

--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
 					"default": false,
 					"description": "If true, Escape key works as the Meta prefix."
 				},
+				"emacs-mcx.useMetaPrefixMacCmd": {
+					"type": "boolean",
+					"default": false,
+					"description": "If true, Command (⌘) key works as the Meta prefix (macOS only)."
+				},
 				"emacs-mcx.debug.silent": {
 					"type": "boolean",
 					"description": "If true, all logs are suppressed.",
@@ -293,15 +298,27 @@
 			},
 			{
 				"key": "alt+f",
-				"mac": "cmd+f",
 				"command": "emacs-mcx.forwardWord",
 				"when": "editorTextFocus"
+			},
+			{
+				"mac": "cmd+f",
+				"command": "emacs-mcx.forwardWord",
+				"when": "editorTextFocus && config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "alt+f",
-				"mac": "cmd+f",
 				"command": "emacs-mcx.executeCommands",
 				"when": "editorFocus && findWidgetVisible",
+				"args": [
+					"closeFindWidget",
+					"emacs-mcx.forwardWord"
+				]
+			},
+			{
+				"mac": "cmd+f",
+				"command": "emacs-mcx.executeCommands",
+				"when": "editorFocus && findWidgetVisible && config.emacs-mcx.useMetaPrefixMacCmd",
 				"args": [
 					"closeFindWidget",
 					"emacs-mcx.forwardWord"
@@ -323,15 +340,27 @@
 			},
 			{
 				"key": "alt+b",
-				"mac": "cmd+b",
 				"command": "emacs-mcx.backwardWord",
 				"when": "editorTextFocus"
 			},
 			{
-				"key": "alt+b",
 				"mac": "cmd+b",
+				"command": "emacs-mcx.backwardWord",
+				"when": "editorTextFocus && config.emacs-mcx.useMetaPrefixMacCmd"
+			},
+			{
+				"key": "alt+b",
 				"command": "emacs-mcx.executeCommands",
 				"when": "editorFocus && findWidgetVisible",
+				"args": [
+					"closeFindWidget",
+					"emacs-mcx.backwardWord"
+				]
+			},
+			{
+				"mac": "cmd+b",
+				"command": "emacs-mcx.executeCommands",
+				"when": "editorFocus && findWidgetVisible && config.emacs-mcx.useMetaPrefixMacCmd",
 				"args": [
 					"closeFindWidget",
 					"emacs-mcx.backwardWord"
@@ -383,15 +412,23 @@
 			},
 			{
 				"key": "alt+v",
-				"mac": "cmd+v",
 				"command": "emacs-mcx.scrollDownCommand",
 				"when": "editorTextFocus && !suggestWidgetVisible"
 			},
 			{
-				"key": "alt+v",
 				"mac": "cmd+v",
+				"command": "emacs-mcx.scrollDownCommand",
+				"when": "editorTextFocus && !suggestWidgetVisible && config.emacs-mcx.useMetaPrefixMacCmd"
+			},
+			{
+				"key": "alt+v",
 				"command": "closeFindWidget",
 				"when": "editorFocus && findWidgetVisible"
+			},
+			{
+				"mac": "cmd+v",
+				"command": "closeFindWidget",
+				"when": "editorFocus && findWidgetVisible && config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "escape v",
@@ -405,9 +442,13 @@
 			},
 			{
 				"key": "alt+shift+[",
-				"mac": "cmd+shift+[",
 				"command": "emacs-mcx.backwardParagraph",
 				"when": "editorTextFocus && !suggestWidgetVisible"
+			},
+			{
+				"mac": "cmd+shift+[",
+				"command": "emacs-mcx.backwardParagraph",
+				"when": "editorTextFocus && !suggestWidgetVisible && config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "escape shift+[",
@@ -416,9 +457,13 @@
 			},
 			{
 				"key": "alt+shift+]",
-				"mac": "cmd+shift+]",
 				"command": "emacs-mcx.forwardParagraph",
 				"when": "editorTextFocus && !suggestWidgetVisible"
+			},
+			{
+				"mac": "cmd+shift+]",
+				"command": "emacs-mcx.forwardParagraph",
+				"when": "editorTextFocus && !suggestWidgetVisible && config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "escape shift+]",
@@ -427,15 +472,27 @@
 			},
 			{
 				"key": "alt+shift+.",
-				"mac": "cmd+shift+.",
 				"command": "emacs-mcx.endOfBuffer",
 				"when": "editorTextFocus"
+			},
+			{
+				"mac": "cmd+shift+.",
+				"command": "emacs-mcx.endOfBuffer",
+				"when": "editorTextFocus && config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "alt+shift+.",
-				"mac": "cmd+shift+.",
 				"command": "emacs-mcx.executeCommands",
 				"when": "editorFocus && findWidgetVisible",
+				"args": [
+					"closeFindWidget",
+					"emacs-mcx.endOfBuffer"
+				]
+			},
+			{
+				"mac": "cmd+shift+.",
+				"command": "emacs-mcx.executeCommands",
+				"when": "editorFocus && findWidgetVisible && config.emacs-mcx.useMetaPrefixMacCmd",
 				"args": [
 					"closeFindWidget",
 					"emacs-mcx.endOfBuffer"
@@ -457,15 +514,27 @@
 			},
 			{
 				"key": "alt+shift+,",
-				"mac": "cmd+shift+,",
 				"command": "emacs-mcx.beginningOfBuffer",
 				"when": "editorTextFocus"
 			},
 			{
-				"key": "alt+shift+,",
 				"mac": "cmd+shift+,",
+				"command": "emacs-mcx.beginningOfBuffer",
+				"when": "editorTextFocus && config.emacs-mcx.useMetaPrefixMacCmd"
+			},
+			{
+				"key": "alt+shift+,",
 				"command": "emacs-mcx.executeCommands",
 				"when": "editorFocus && findWidgetVisible",
+				"args": [
+					"closeFindWidget",
+					"emacs-mcx.beginningOfBuffer"
+				]
+			},
+			{
+				"mac": "cmd+shift+,",
+				"command": "emacs-mcx.executeCommands",
+				"when": "editorFocus && findWidgetVisible && config.emacs-mcx.useMetaPrefixMacCmd",
 				"args": [
 					"closeFindWidget",
 					"emacs-mcx.beginningOfBuffer"
@@ -487,17 +556,24 @@
 			},
 			{
 				"key": "alt+g alt+g",
-				"mac": "cmd+g cmd+g",
 				"command": "workbench.action.gotoLine"
+			},
+			{
+				"mac": "cmd+g cmd+g",
+				"command": "workbench.action.gotoLine",
+				"when": "config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "alt+g g",
-				"mac": "cmd+g g",
 				"command": "workbench.action.gotoLine"
 			},
 			{
+				"mac": "cmd+g g",
+				"command": "workbench.action.gotoLine",
+				"when": "config.emacs-mcx.useMetaPrefixMacCmd"
+			},
+			{
 				"key": "alt+g alt+g",
-				"mac": "cmd+g cmd+g",
 				"command": "emacs-mcx.executeCommands",
 				"when": "editorFocus && findWidgetVisible",
 				"args": [
@@ -506,10 +582,27 @@
 				]
 			},
 			{
+				"mac": "cmd+g cmd+g",
+				"command": "emacs-mcx.executeCommands",
+				"when": "editorFocus && findWidgetVisible && config.emacs-mcx.useMetaPrefixMacCmd",
+				"args": [
+					"closeFindWidget",
+					"workbench.action.gotoLine"
+				]
+			},
+			{
 				"key": "alt+g g",
-				"mac": "cmd+g g",
 				"command": "emacs-mcx.executeCommands",
 				"when": "editorFocus && findWidgetVisible",
+				"args": [
+					"closeFindWidget",
+					"workbench.action.gotoLine"
+				]
+			},
+			{
+				"mac": "cmd+g g",
+				"command": "emacs-mcx.executeCommands",
+				"when": "editorFocus && findWidgetVisible && config.emacs-mcx.useMetaPrefixMacCmd",
 				"args": [
 					"closeFindWidget",
 					"workbench.action.gotoLine"
@@ -522,13 +615,21 @@
 			},
 			{
 				"key": "alt+g n",
-				"mac": "cmd+g n",
 				"command": "editor.action.marker.next"
 			},
 			{
+				"mac": "cmd+g n",
+				"command": "editor.action.marker.next",
+				"when": "config.emacs-mcx.useMetaPrefixMacCmd"
+			},
+			{
 				"key": "alt+g alt+n",
-				"mac": "cmd+g cmd+n",
 				"command": "editor.action.marker.next"
+			},
+			{
+				"mac": "cmd+g cmd+n",
+				"command": "editor.action.marker.next",
+				"when": "config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "ctrl+x `",
@@ -536,13 +637,21 @@
 			},
 			{
 				"key": "alt+g p",
-				"mac": "cmd+g p",
 				"command": "editor.action.marker.prev"
 			},
 			{
+				"mac": "cmd+g p",
+				"command": "editor.action.marker.prev",
+				"when": "config.emacs-mcx.useMetaPrefixMacCmd"
+			},
+			{
 				"key": "alt+g alt+p",
-				"mac": "cmd+g cmd+p",
 				"command": "editor.action.marker.prev"
+			},
+			{
+				"mac": "cmd+g cmd+p",
+				"command": "editor.action.marker.prev",
+				"when": "config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "ctrl+l",
@@ -571,9 +680,13 @@
 			},
 			{
 				"key": "alt+shift+5",
-				"mac": "cmd+shift+5",
 				"command": "editor.action.startFindReplaceAction",
 				"when": "editorFocus"
+			},
+			{
+				"mac": "cmd+shift+5",
+				"command": "editor.action.startFindReplaceAction",
+				"when": "editorFocus && config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "escape shift+5",
@@ -582,9 +695,13 @@
 			},
 			{
 				"key": "ctrl+alt+n",
-				"mac": "ctrl+cmd+n",
 				"command": "emacs-mcx.addSelectionToNextFindMatch",
 				"when": "editorFocus"
+			},
+			{
+				"mac": "ctrl+cmd+n",
+				"command": "emacs-mcx.addSelectionToNextFindMatch",
+				"when": "editorFocus && config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "escape ctrl+n",
@@ -593,14 +710,18 @@
 			},
 			{
 				"key": "ctrl+alt+p",
-				"mac": "ctrl+cmd+p",
 				"command": "emacs-mcx.addSelectionToPreviousFindMatch",
 				"when": "editorFocus"
 			},
 			{
+				"mac": "ctrl+cmd+p",
+				"command": "emacs-mcx.addSelectionToPreviousFindMatch",
+				"when": "editorFocus && config.emacs-mcx.useMetaPrefixMacCmd"
+			},
+			{
 				"key": "escape ctrl+p",
 				"command": "emacs-mcx.addSelectionToPreviousFindMatch",
-				"when": "editorFocus &&  && config.emacs-mcx.useMetaPrefixEscape"
+				"when": "editorFocus && config.emacs-mcx.useMetaPrefixEscape"
 			},
 			{
 				"key": "ctrl+d",
@@ -619,9 +740,13 @@
 			},
 			{
 				"key": "alt+d",
-				"mac": "cmd+d",
 				"command": "emacs-mcx.killWord",
 				"when": "editorTextFocus && !editorReadonly"
+			},
+			{
+				"mac": "cmd+d",
+				"command": "emacs-mcx.killWord",
+				"when": "editorTextFocus && !editorReadonly && config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "escape d",
@@ -630,9 +755,13 @@
 			},
 			{
 				"key": "alt+backspace",
-				"mac": "cmd+backspace",
 				"command": "emacs-mcx.backwardKillWord",
 				"when": "editorTextFocus && !editorReadonly"
+			},
+			{
+				"mac": "cmd+backspace",
+				"command": "emacs-mcx.backwardKillWord",
+				"when": "editorTextFocus && !editorReadonly && config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "escape backspace",
@@ -661,15 +790,23 @@
 			},
 			{
 				"key": "alt+w",
-				"mac": "cmd+w",
 				"command": "emacs-mcx.copyRegion",
 				"when": "editorTextFocus"
 			},
 			{
-				"key": "alt+w",
 				"mac": "cmd+w",
+				"command": "emacs-mcx.copyRegion",
+				"when": "editorTextFocus && config.emacs-mcx.useMetaPrefixMacCmd"
+			},
+			{
+				"key": "alt+w",
 				"command": "closeFindWidget",
 				"when": "editorFocus && findWidgetVisible"
+			},
+			{
+				"mac": "cmd+w",
+				"command": "closeFindWidget",
+				"when": "editorFocus && findWidgetVisible && config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "escape w",
@@ -693,15 +830,23 @@
 			},
 			{
 				"key": "alt+y",
-				"mac": "cmd+y",
 				"command": "emacs-mcx.yank-pop",
 				"when": "editorTextFocus && !editorReadonly"
 			},
 			{
-				"key": "alt+y",
 				"mac": "cmd+y",
+				"command": "emacs-mcx.yank-pop",
+				"when": "editorTextFocus && !editorReadonly && config.emacs-mcx.useMetaPrefixMacCmd"
+			},
+			{
+				"key": "alt+y",
 				"command": "closeFindWidget",
 				"when": "editorFocus && findWidgetVisible"
+			},
+			{
+				"mac": "cmd+y",
+				"command": "closeFindWidget",
+				"when": "editorFocus && findWidgetVisible && config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "escape y",
@@ -815,15 +960,27 @@
 			},
 			{
 				"key": "alt+;",
-				"mac": "cmd+;",
 				"command": "editor.action.blockComment",
 				"when": "editorTextFocus && !editorReadonly"
 			},
 			{
-				"key": "alt+;",
 				"mac": "cmd+;",
+				"command": "editor.action.blockComment",
+				"when": "editorTextFocus && !editorReadonly && config.emacs-mcx.useMetaPrefixMacCmd"
+			},
+			{
+				"key": "alt+;",
 				"command": "emacs-mcx.executeCommands",
 				"when": "editorFocus && findWidgetVisible",
+				"args": [
+					"closeFindWidget",
+					"editor.action.blockComment"
+				]
+			},
+			{
+				"mac": "cmd+;",
+				"command": "emacs-mcx.executeCommands",
+				"when": "editorFocus && findWidgetVisible && config.emacs-mcx.useMetaPrefixMacCmd",
 				"args": [
 					"closeFindWidget",
 					"editor.action.blockComment"
@@ -850,9 +1007,13 @@
 			},
 			{
 				"key": "alt+l",
-				"mac": "cmd+l",
 				"command": "emacs-mcx.transformToLowercase",
 				"when": "editorTextFocus && !editorReadonly"
+			},
+			{
+				"mac": "cmd+l",
+				"command": "emacs-mcx.transformToLowercase",
+				"when": "editorTextFocus && !editorReadonly && config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "escape l",
@@ -866,9 +1027,13 @@
 			},
 			{
 				"key": "alt+u",
-				"mac": "cmd+u",
 				"command": "emacs-mcx.transformToUppercase",
 				"when": "editorTextFocus && !editorReadonly"
+			},
+			{
+				"mac": "cmd+u",
+				"command": "emacs-mcx.transformToUppercase",
+				"when": "editorTextFocus && !editorReadonly && config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "escape u",
@@ -877,9 +1042,13 @@
 			},
 			{
 				"key": "alt+c",
-				"mac": "cmd+c",
 				"command": "emacs-mcx.transformToTitlecase",
 				"when": "editorTextFocus && !editorReadonly"
+			},
+			{
+				"mac": "cmd+c",
+				"command": "emacs-mcx.transformToTitlecase",
+				"when": "editorTextFocus && !editorReadonly && config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "escape c",
@@ -888,9 +1057,17 @@
 			},
 			{
 				"key": "alt+shift+6",
-				"mac": "cmd+shift+6",
 				"command": "emacs-mcx.executeCommands",
 				"when": "editorTextFocus && !editorReadOnly",
+				"args": [
+					"emacs-mcx.previousLine",
+					"editor.action.joinLines"
+				]
+			},
+			{
+				"mac": "cmd+shift+6",
+				"command": "emacs-mcx.executeCommands",
+				"when": "editorTextFocus && !editorReadOnly && config.emacs-mcx.useMetaPrefixMacCmd",
 				"args": [
 					"emacs-mcx.previousLine",
 					"editor.action.joinLines"
@@ -1007,8 +1184,12 @@
 			},
 			{
 				"key": "alt+x",
-				"mac": "cmd+x",
 				"command": "workbench.action.showCommands"
+			},
+			{
+				"mac": "cmd+x",
+				"command": "workbench.action.showCommands",
+				"when": "config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "escape x",
@@ -1017,8 +1198,12 @@
 			},
 			{
 				"key": "ctrl+alt+space",
-				"mac": "ctrl+cmd+space",
 				"command": "workbench.action.toggleSidebarVisibility"
+			},
+			{
+				"mac": "ctrl+cmd+space",
+				"command": "workbench.action.toggleSidebarVisibility",
+				"when": "config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "escape ctrl+space",
@@ -1090,9 +1275,13 @@
 			},
 			{
 				"key": "ctrl+alt+f",
-				"mac": "ctrl+cmd+f",
 				"command": "emacs-mcx.paredit.forwardSexp",
 				"when": "editorTextFocus"
+			},
+			{
+				"mac": "ctrl+cmd+f",
+				"command": "emacs-mcx.paredit.forwardSexp",
+				"when": "editorTextFocus && config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "escape ctrl+f",
@@ -1101,9 +1290,13 @@
 			},
 			{
 				"key": "ctrl+alt+b",
-				"mac": "ctrl+cmd+b",
 				"command": "emacs-mcx.paredit.backwardSexp",
 				"when": "editorTextFocus"
+			},
+			{
+				"mac": "ctrl+cmd+b",
+				"command": "emacs-mcx.paredit.backwardSexp",
+				"when": "editorTextFocus && config.emacs-mcx.useMetaPrefixMacCmd"
 			},
 			{
 				"key": "escape ctrl+b",


### PR DESCRIPTION
Add `emacs-mcx.useMetaPrefixMacCmd` config to make macOS' command key to work as a meta prefix key.
The command key config is derived from #244 
This configuration is inspired by #215 .