### PR TITLE
switch C-x b to showAllEditorsByRecentlyUsed

### DIFF
--- a/keybindings.json
+++ b/keybindings.json
@@ -625,7 +625,7 @@
     },
     {
       "key": "ctrl+x b",
-      "command": "workbench.action.showAllEditors"
+      "command": "workbench.action.showAllEditorsByRecentlyUsed"
     },
     {
       "key": "ctrl+x k",

--- a/package.json
+++ b/package.json
@@ -1309,7 +1309,7 @@
 			},
 			{
 				"key": "ctrl+x b",
-				"command": "workbench.action.showAllEditors"
+				"command": "workbench.action.showAllEditorsByRecentlyUsed"
 			},
 			{
 				"key": "ctrl+x k",


### PR DESCRIPTION
The January 2020 VSCode update introduced the
`workbench.action.showAllEditorsByRecentlyUsed` command.  This command
is a closer analog to Emacs' switch buffer.