### PR TITLE
Fix showAllEditorsByRecentlyUsed to showAllEditorsByMostRecentlyUsed

### DIFF
--- a/keybindings.json
+++ b/keybindings.json
@@ -625,7 +625,7 @@
     },
     {
       "key": "ctrl+x b",
-      "command": "workbench.action.showAllEditorsByRecentlyUsed"
+      "command": "workbench.action.showAllEditorsByMostRecentlyUsed"
     },
     {
       "key": "ctrl+x k",

--- a/package.json
+++ b/package.json
@@ -1309,7 +1309,7 @@
 			},
 			{
 				"key": "ctrl+x b",
-				"command": "workbench.action.showAllEditorsByRecentlyUsed"
+				"command": "workbench.action.showAllEditorsByMostRecentlyUsed"
 			},
 			{
 				"key": "ctrl+x k",


### PR DESCRIPTION
Fixes #289 