### PR TITLE
alt+w when find widget visible

### DIFF
--- a/keybindings.json
+++ b/keybindings.json
@@ -317,8 +317,12 @@
     },
     {
       "key": "meta+w",
-      "command": "closeFindWidget",
-      "when": "editorFocus && findWidgetVisible"
+      "command": "emacs-mcx.executeCommands",
+      "when": "editorFocus && findWidgetVisible",
+      "args": [
+        "closeFindWidget",
+        "emacs-mcx.copyRegion"
+      ]
     },
     {
       "key": "ctrl+y",

--- a/package.json
+++ b/package.json
@@ -867,19 +867,31 @@
 			},
 			{
 				"key": "alt+w",
-				"command": "closeFindWidget",
-				"when": "editorFocus && findWidgetVisible && !config.emacs-mcx.useMetaPrefixMacCmd"
+				"command": "emacs-mcx.executeCommands",
+				"when": "editorFocus && findWidgetVisible && !config.emacs-mcx.useMetaPrefixMacCmd",
+				"args": [
+					"closeFindWidget",
+					"emacs-mcx.copyRegion"
+				]
 			},
 			{
 				"key": "alt+w",
 				"mac": "cmd+w",
-				"command": "closeFindWidget",
-				"when": "editorFocus && findWidgetVisible && config.emacs-mcx.useMetaPrefixMacCmd"
+				"command": "emacs-mcx.executeCommands",
+				"when": "editorFocus && findWidgetVisible && config.emacs-mcx.useMetaPrefixMacCmd",
+				"args": [
+					"closeFindWidget",
+					"emacs-mcx.copyRegion"
+				]
 			},
 			{
 				"key": "escape w",
-				"command": "closeFindWidget",
-				"when": "editorFocus && findWidgetVisible && config.emacs-mcx.useMetaPrefixEscape"
+				"command": "emacs-mcx.executeCommands",
+				"when": "editorFocus && findWidgetVisible && config.emacs-mcx.useMetaPrefixEscape",
+				"args": [
+					"closeFindWidget",
+					"emacs-mcx.copyRegion"
+				]
 			},
 			{
 				"key": "ctrl+y",


### PR DESCRIPTION
`alt+w` binding when find widget visible changed from close the find widget only, to first close find widget then copy region.