### PR TITLE
restrict ctrl+x <key> bindings to editorTextFocus only

### DIFF
--- a/keybindings.json
+++ b/keybindings.json
@@ -214,7 +214,8 @@
     },
     {
       "key": "ctrl+x `",
-      "command": "editor.action.marker.next"
+      "command": "editor.action.marker.next",
+      "when": "editorTextFocus"
     },
     // marker prev
     {
@@ -607,11 +608,13 @@
     // Workspace
     {
       "key": "ctrl+x z",
-      "command": "workbench.action.toggleZenMode"
+      "command": "workbench.action.toggleZenMode",
+      "when": "editorTextFocus"
     },
     {
       "key": "ctrl+x ctrl+f",
-      "command": "workbench.action.quickOpen"
+      "command": "workbench.action.quickOpen",
+      "when": "editorTextFocus"
     },
     {
       "key": "ctrl+x ctrl+s",
@@ -625,43 +628,53 @@
     },
     {
       "key": "ctrl+x ctrl+n",
-      "command": "workbench.action.newWindow"
+      "command": "workbench.action.newWindow",
+      "when": "editorTextFocus"
     },
     {
       "key": "ctrl+x b",
-      "command": "workbench.action.showAllEditorsByMostRecentlyUsed"
+      "command": "workbench.action.showAllEditorsByMostRecentlyUsed",
+      "when": "editorTextFocus"
     },
     {
       "key": "ctrl+x k",
-      "command": "workbench.action.closeActiveEditor"
+      "command": "workbench.action.closeActiveEditor",
+      "when": "editorTextFocus"
     },
     {
       "key": "ctrl+x ctrl-k",
-      "command": "workbench.action.closeAllEditors"
+      "command": "workbench.action.closeAllEditors",
+      "when": "editorTextFocus"
     },
     {
       "key": "ctrl+x 0",
-      "command": "workbench.action.closeEditorsInGroup"
+      "command": "workbench.action.closeEditorsInGroup",
+      "when": "editorTextFocus"
     },
     {
       "key": "ctrl+x 1",
-      "command": "workbench.action.closeEditorsInOtherGroups"
+      "command": "workbench.action.closeEditorsInOtherGroups",
+      "when": "editorTextFocus"
     },
     {
       "key": "ctrl+x 2",
-      "command": "workbench.action.splitEditorDown"
+      "command": "workbench.action.splitEditorDown",
+      "when": "editorTextFocus"
     },
     {
       "key": "ctrl+x 3",
-      "command": "workbench.action.splitEditorRight"
+      "command": "workbench.action.splitEditorRight",
+      "when": "editorTextFocus"
     },
     {
       "key": "ctrl+x 4",
-      "command": "workbench.action.toggleEditorGroupLayout"
+      "command": "workbench.action.toggleEditorGroupLayout",
+      "when": "editorTextFocus"
     },
     {
       "key": "ctrl+x o",
-      "command": "workbench.action.navigateEditorGroups"
+      "command": "workbench.action.navigateEditorGroups",
+      "when": "editorTextFocus"
     },
     {
       "key": "ctrl+u",
@@ -725,7 +738,8 @@
     },
     {
       "key": "ctrl+x j",
-      "command": "workbench.action.togglePanel"
+      "command": "workbench.action.togglePanel",
+      "when": "editorTextFocus"
     },
     {
       "key": "ctrl+i",

--- a/package.json
+++ b/package.json
@@ -685,7 +685,8 @@
 			},
 			{
 				"key": "ctrl+x `",
-				"command": "editor.action.marker.next"
+				"command": "editor.action.marker.next",
+				"when": "editorTextFocus"
 			},
 			{
 				"key": "alt+g p",
@@ -1304,11 +1305,13 @@
 			},
 			{
 				"key": "ctrl+x z",
-				"command": "workbench.action.toggleZenMode"
+				"command": "workbench.action.toggleZenMode",
+				"when": "editorTextFocus"
 			},
 			{
 				"key": "ctrl+x ctrl+f",
-				"command": "workbench.action.quickOpen"
+				"command": "workbench.action.quickOpen",
+				"when": "editorTextFocus"
 			},
 			{
 				"key": "ctrl+x ctrl+s",
@@ -1322,43 +1325,53 @@
 			},
 			{
 				"key": "ctrl+x ctrl+n",
-				"command": "workbench.action.newWindow"
+				"command": "workbench.action.newWindow",
+				"when": "editorTextFocus"
 			},
 			{
 				"key": "ctrl+x b",
-				"command": "workbench.action.showAllEditorsByMostRecentlyUsed"
+				"command": "workbench.action.showAllEditorsByMostRecentlyUsed",
+				"when": "editorTextFocus"
 			},
 			{
 				"key": "ctrl+x k",
-				"command": "workbench.action.closeActiveEditor"
+				"command": "workbench.action.closeActiveEditor",
+				"when": "editorTextFocus"
 			},
 			{
 				"key": "ctrl+x ctrl-k",
-				"command": "workbench.action.closeAllEditors"
+				"command": "workbench.action.closeAllEditors",
+				"when": "editorTextFocus"
 			},
 			{
 				"key": "ctrl+x 0",
-				"command": "workbench.action.closeEditorsInGroup"
+				"command": "workbench.action.closeEditorsInGroup",
+				"when": "editorTextFocus"
 			},
 			{
 				"key": "ctrl+x 1",
-				"command": "workbench.action.closeEditorsInOtherGroups"
+				"command": "workbench.action.closeEditorsInOtherGroups",
+				"when": "editorTextFocus"
 			},
 			{
 				"key": "ctrl+x 2",
-				"command": "workbench.action.splitEditorDown"
+				"command": "workbench.action.splitEditorDown",
+				"when": "editorTextFocus"
 			},
 			{
 				"key": "ctrl+x 3",
-				"command": "workbench.action.splitEditorRight"
+				"command": "workbench.action.splitEditorRight",
+				"when": "editorTextFocus"
 			},
 			{
 				"key": "ctrl+x 4",
-				"command": "workbench.action.toggleEditorGroupLayout"
+				"command": "workbench.action.toggleEditorGroupLayout",
+				"when": "editorTextFocus"
 			},
 			{
 				"key": "ctrl+x o",
-				"command": "workbench.action.navigateEditorGroups"
+				"command": "workbench.action.navigateEditorGroups",
+				"when": "editorTextFocus"
 			},
 			{
 				"key": "ctrl+u",
@@ -1444,7 +1457,8 @@
 			},
 			{
 				"key": "ctrl+x j",
-				"command": "workbench.action.togglePanel"
+				"command": "workbench.action.togglePanel",
+				"when": "editorTextFocus"
 			},
 			{
 				"key": "ctrl+i",


### PR DESCRIPTION
This makes sure ctrl+x is not picked up in terminalFocus.

See more in issue: https://github.com/tuttieee/vscode-emacs-mcx/issues/344