### PR TITLE
Fix to simply override replacePreviousChar command without no effects in order for type command to work correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "emacs-mcx",
 	"displayName": "Awesome Emacs Keymap",
 	"description": "Emacs Friendly Keymap with multi cursor support, improved mark-mode experience, clipboard and kill-ring integration, and lots of improvements and bug fixes.",
-	"version": "0.20.2",
+	"version": "0.21.0-dev0",
 	"publisher": "tuttieee",
 	"repository": {
 		"type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,6 +82,14 @@ export function activate(context: vscode.ExtensionContext) {
     (args) => vscode.commands.executeCommand("default:type", args)
   );
 
+  // Simply override replacePreviousChar command without any effects in order for overridden `type` command to work correctly.
+  // See https://github.com/microsoft/vscode/issues/102291#issuecomment-661758632
+  context.subscriptions.push(
+    vscode.commands.registerCommand("replacePreviousChar", (...args) =>
+      vscode.commands.executeCommand("default:replacePreviousChar", ...args)
+    )
+  );
+
   moveCommandIds.map((commandName) => {
     registerEmulatorCommand(`emacs-mcx.${commandName}`, (emulator) => {
       emulator.runCommand(commandName);


### PR DESCRIPTION
Related to #115