### PR TITLE
Fix PrefixArgumentHandler state management

### DIFF
--- a/src/prefix-argument.ts
+++ b/src/prefix-argument.ts
@@ -1,24 +1,46 @@
 import { logger } from "./logger";
 import { MessageManager } from "./message";
 
+interface PrefixArgumentHandlerState {
+  isInPrefixArgumentMode: boolean;
+  isAcceptingPrefixArgument: boolean;
+  cuCount: number; // How many C-u are input continuously
+  prefixArgumentStr: string; // Prefix argument string input after C-u
+}
+
 export class PrefixArgumentHandler {
-  private isInPrefixArgumentMode = false;
-  private isAcceptingPrefixArgument = false;
-  private cuCount = 0; // How many C-u are input continuously
-  private prefixArgumentStr = ""; // Prefix argument string input after C-u
+  private state: PrefixArgumentHandlerState;
+
+  public constructor() {
+    this.state = {
+      isInPrefixArgumentMode: false,
+      isAcceptingPrefixArgument: false,
+      cuCount: 0,
+      prefixArgumentStr: "",
+    };
+  }
+
+  private updateState(newState: Partial<PrefixArgumentHandlerState>): void {
+    this.state = {
+      ...this.state,
+      ...newState,
+    };
+  }
 
   public handleType(text: string): boolean {
-    if (!this.isInPrefixArgumentMode) {
+    if (!this.state.isInPrefixArgumentMode) {
       logger.debug(`[PrefixArgumentHandler.handleType]\t Not in prefix argument mode. exit.`);
       return false;
     }
 
-    if (this.isAcceptingPrefixArgument && !isNaN(+text)) {
+    if (this.state.isAcceptingPrefixArgument && !isNaN(+text)) {
       // If `text` is a numeric charactor
-      this.prefixArgumentStr += text;
-      MessageManager.showMessage(`C-u ${this.prefixArgumentStr}-`);
+      this.updateState({
+        prefixArgumentStr: this.state.prefixArgumentStr + text,
+      });
+      MessageManager.showMessage(`C-u ${this.state.prefixArgumentStr}-`);
 
-      logger.debug(`[PrefixArgumentHandler.handleType]\t Prefix argument is "${this.prefixArgumentStr}"`);
+      logger.debug(`[PrefixArgumentHandler.handleType]\t Prefix argument is "${this.state.prefixArgumentStr}"`);
       return true;
     }
 
@@ -30,34 +52,40 @@ export class PrefixArgumentHandler {
    * Emacs' ctrl-u
    */
   public universalArgument() {
-    if (this.isInPrefixArgumentMode && this.prefixArgumentStr.length > 0) {
+    if (this.state.isInPrefixArgumentMode && this.state.prefixArgumentStr.length > 0) {
       logger.debug(`[PrefixArgumentHandler.universalArgument]\t Stop accepting prefix argument.`);
-      this.isAcceptingPrefixArgument = false;
+      this.updateState({
+        isAcceptingPrefixArgument: false,
+      });
     } else {
       logger.debug(`[PrefixArgumentHandler.universalArgument]\t Start prefix argument or count up C-u.`);
-      this.isInPrefixArgumentMode = true;
-      this.isAcceptingPrefixArgument = true;
-      this.cuCount++;
-      this.prefixArgumentStr = "";
+      this.updateState({
+        isInPrefixArgumentMode: true,
+        isAcceptingPrefixArgument: true,
+        cuCount: this.state.cuCount + 1,
+        prefixArgumentStr: "",
+      });
     }
   }
 
   public cancel() {
     logger.debug(`[PrefixArgumentHandler.cancel]`);
-    this.isInPrefixArgumentMode = false;
-    this.isAcceptingPrefixArgument = false;
-    this.cuCount = 0;
-    this.prefixArgumentStr = "";
+    this.updateState({
+      isInPrefixArgumentMode: false,
+      isAcceptingPrefixArgument: false,
+      cuCount: 0,
+      prefixArgumentStr: "",
+    });
   }
 
   public getPrefixArgument(): number | undefined {
-    if (!this.isInPrefixArgumentMode) {
+    if (!this.state.isInPrefixArgumentMode) {
       return undefined;
     }
 
-    const prefixArgument = parseInt(this.prefixArgumentStr, 10);
+    const prefixArgument = parseInt(this.state.prefixArgumentStr, 10);
     if (isNaN(prefixArgument)) {
-      return 4 ** this.cuCount;
+      return 4 ** this.state.cuCount;
     }
     return prefixArgument;
   }
@@ -69,6 +97,6 @@ export class PrefixArgumentHandler {
    * and have to be handled by this extension in its own way.
    */
   public precedingSingleCtrlU(): boolean {
-    return this.isInPrefixArgumentMode && this.cuCount === 1;
+    return this.state.isInPrefixArgumentMode && this.state.cuCount === 1;
   }
 }

--- a/src/prefix-argument.ts
+++ b/src/prefix-argument.ts
@@ -21,10 +21,23 @@ export class PrefixArgumentHandler {
   }
 
   private updateState(newState: Partial<PrefixArgumentHandlerState>): void {
+    const oldState = this.state;
     this.state = {
       ...this.state,
       ...newState,
     };
+    if (oldState.isAcceptingPrefixArgument !== this.state.isAcceptingPrefixArgument) {
+      logger.debug(
+        `[PrefixArgumentHandler]\t isAcceptingPrefixArgument changed: ${this.state.isAcceptingPrefixArgument}.`
+      );
+    }
+    if (
+      oldState.isInPrefixArgumentMode !== this.state.isInPrefixArgumentMode ||
+      oldState.prefixArgumentStr !== this.state.prefixArgumentStr ||
+      oldState.cuCount !== this.state.cuCount
+    ) {
+      logger.debug(`[PrefixArgumentHandler]\t prefix argument changed: ${this.getPrefixArgument()}.`);
+    }
   }
 
   public handleType(text: string): boolean {


### PR DESCRIPTION
For #457 .
PrefixArgumentHandler's event listeners callers can now be in `updateState()`