### PR TITLE
Allow navigation within query replace prompt

### DIFF
--- a/keybindings.json
+++ b/keybindings.json
@@ -9,7 +9,7 @@
     {
       "keys": ["right", "ctrl+f"],
       "command": "emacs-mcx.executeCommands",
-      "when": "editorFocus && findWidgetVisible",
+      "when": "editorFocus && findWidgetVisible && !replaceInputFocussed",
       "args": [
         "closeFindWidget",
         "emacs-mcx.forwardChar",
@@ -25,7 +25,7 @@
     {
       "keys": ["left", "ctrl+b"],
       "command": "emacs-mcx.executeCommands",
-      "when": "editorFocus && findWidgetVisible",
+      "when": "editorFocus && findWidgetVisible && !replaceInputFocussed",
       "args": [
         "closeFindWidget",
         "emacs-mcx.forwardChar",
@@ -51,7 +51,7 @@
     {
       "keys": ["up", "ctrl+p"],
       "command": "emacs-mcx.executeCommands",
-      "when": "editorFocus && findWidgetVisible",
+      "when": "editorFocus && findWidgetVisible && !replaceInputFocussed",
       "args": [
         "closeFindWidget",
         "emacs-mcx.forwardChar",
@@ -77,7 +77,7 @@
     {
       "keys": ["down", "ctrl+n"],
       "command": "emacs-mcx.executeCommands",
-      "when": "editorFocus && findWidgetVisible",
+      "when": "editorFocus && findWidgetVisible && !replaceInputFocussed",
       "args": [
         "closeFindWidget",
         "emacs-mcx.forwardChar",
@@ -93,7 +93,7 @@
     {
       "keys": ["home", "ctrl+a"],
       "command": "emacs-mcx.executeCommands",
-      "when": "editorFocus && findWidgetVisible",
+      "when": "editorFocus && findWidgetVisible && !replaceInputFocussed",
       "args": [
         "closeFindWidget",
         "emacs-mcx.moveBeginningOfLine"
@@ -108,7 +108,7 @@
     {
       "keys": ["end", "ctrl+e"],
       "command": "emacs-mcx.executeCommands",
-      "when": "editorFocus && findWidgetVisible",
+      "when": "editorFocus && findWidgetVisible && !replaceInputFocussed",
       "args": [
         "closeFindWidget",
         "emacs-mcx.moveEndOfLine"
@@ -123,7 +123,7 @@
     {
       "key": "meta+f",
       "command": "emacs-mcx.executeCommands",
-      "when": "editorFocus && findWidgetVisible",
+      "when": "editorFocus && findWidgetVisible && !replaceInputFocussed",
       "args": [
         "closeFindWidget",
         "emacs-mcx.forwardWord"
@@ -138,7 +138,7 @@
     {
       "key": "meta+b",
       "command": "emacs-mcx.executeCommands",
-      "when": "editorFocus && findWidgetVisible",
+      "when": "editorFocus && findWidgetVisible && !replaceInputFocussed",
       "args": [
         "closeFindWidget",
         "emacs-mcx.backwardWord"


### PR DESCRIPTION
This modifies the keybindings to better match emacs behaviour:

- Searches (C-s) are interrupted by any navigation (arrow keys, M-b, whatever) (the current behaviour)
- Query replaces (M-%) move the focus to the minibuffer immediately, and any navigation navigates within the minibuffer (and does not close the search/replace).

Note that I only added the conditionals for basic navigation commands. For example,
the binding for `ctrl+/` (undo) still closes the query replace widget. I'm not sure
this is desired -- possibly every binding condition should be changed to
`editorFocus && findWidgetVisible && !replaceInputFocussed`.

(Relates to https://github.com/tuttieee/vscode-emacs-mcx/issues/360)