### PR TITLE
Added meta+/ for suggestions

### DIFF
--- a/keybindings.json
+++ b/keybindings.json
@@ -640,6 +640,16 @@
       "command": "toggleSuggestionDetails",
       "when": "editorTextFocus && suggestWidgetVisible"
     },
+    {
+      "key": "meta+/",
+      "command": "editor.action.triggerSuggest",
+      "when": "editorTextFocus"
+    },
+    {
+      "key": "meta+/",
+      "command": "toggleSuggestionDetails",
+      "when": "editorTextFocus && suggestWidgetVisible"
+    },
     // Show commands
     {
       "key": "meta+x",

--- a/package.json
+++ b/package.json
@@ -1377,6 +1377,38 @@
 				"when": "editorTextFocus && suggestWidgetVisible"
 			},
 			{
+				"key": "alt+/",
+				"command": "editor.action.triggerSuggest",
+				"when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+			},
+			{
+				"key": "alt+/",
+				"mac": "cmd+/",
+				"command": "editor.action.triggerSuggest",
+				"when": "editorTextFocus && config.emacs-mcx.useMetaPrefixMacCmd"
+			},
+			{
+				"key": "escape /",
+				"command": "editor.action.triggerSuggest",
+				"when": "editorTextFocus && config.emacs-mcx.useMetaPrefixEscape"
+			},
+			{
+				"key": "alt+/",
+				"command": "toggleSuggestionDetails",
+				"when": "editorTextFocus && suggestWidgetVisible && !config.emacs-mcx.useMetaPrefixMacCmd"
+			},
+			{
+				"key": "alt+/",
+				"mac": "cmd+/",
+				"command": "toggleSuggestionDetails",
+				"when": "editorTextFocus && suggestWidgetVisible && config.emacs-mcx.useMetaPrefixMacCmd"
+			},
+			{
+				"key": "escape /",
+				"command": "toggleSuggestionDetails",
+				"when": "editorTextFocus && suggestWidgetVisible && config.emacs-mcx.useMetaPrefixEscape"
+			},
+			{
 				"key": "alt+x",
 				"command": "workbench.action.showCommands",
 				"when": "!config.emacs-mcx.useMetaPrefixMacCmd"


### PR DESCRIPTION
This change binds meta+/ to triggerSuggest to better match the default behavior of emacs modes like hippie expand.  On a Japanese keyboard, ctrl+' requires 3 keys to be pressed because the ' key is shift+7. 

See:

-  https://www.gnu.org/software/emacs/manual/html_node/autotype/Hippie-Expand.html
-  https://www.emacswiki.org/emacs/auto-complete.el