### PR TITLE
Fix kill and yank to work with multicursor in the same way to VSCode native cut and paste

### DIFF
--- a/src/commands/kill.ts
+++ b/src/commands/kill.ts
@@ -175,6 +175,7 @@ export class CopyRegion extends KillYankCommand {
     this.emacsController.exitMarkMode();
     this.killYanker.cancelKillAppend();
     makeSelectionsEmpty(textEditor);
+    revealPrimaryActive(textEditor);
   }
 }
 
@@ -184,6 +185,7 @@ export class Yank extends KillYankCommand {
   public async execute(textEditor: TextEditor, isInMarkMode: boolean, prefixArgument: number | undefined) {
     await this.killYanker.yank();
     this.emacsController.exitMarkMode();
+    revealPrimaryActive(textEditor);
   }
 }
 
@@ -193,5 +195,6 @@ export class YankPop extends KillYankCommand {
   public async execute(textEditor: TextEditor, isInMarkMode: boolean, prefixArgument: number | undefined) {
     await this.killYanker.yankPop();
     this.emacsController.exitMarkMode();
+    revealPrimaryActive(textEditor);
   }
 }

--- a/src/kill-yank/kill-ring-entity/clipboard-text.ts
+++ b/src/kill-yank/kill-ring-entity/clipboard-text.ts
@@ -1,6 +1,7 @@
 import { IKillRingEntity } from "./kill-ring-entity";
 
 export class ClipboardTextKillRingEntity implements IKillRingEntity {
+  public readonly type = "clipboard";
   private text: string;
 
   constructor(clipboardText: string) {

--- a/src/kill-yank/kill-ring-entity/editor-text.ts
+++ b/src/kill-yank/kill-ring-entity/editor-text.ts
@@ -42,6 +42,7 @@ class AppendedRegionTexts {
 }
 
 export class EditorTextKillRingEntity implements IKillRingEntity {
+  public readonly type = "editor";
   private regionTextsList: AppendedRegionTexts[];
 
   constructor(regionTexts: IRegionText[]) {
@@ -84,12 +85,12 @@ export class EditorTextKillRingEntity implements IKillRingEntity {
     return allText;
   }
 
-  public getregionTextsList() {
+  public getRegionTextsList() {
     return this.regionTextsList;
   }
 
   public append(entity: EditorTextKillRingEntity, appendDirection: AppendDirection = AppendDirection.Forward) {
-    const additional = entity.getregionTextsList();
+    const additional = entity.getRegionTextsList();
     if (additional.length !== this.regionTextsList.length) {
       throw Error("Not appendable");
     }

--- a/src/kill-yank/kill-ring-entity/kill-ring-entity.ts
+++ b/src/kill-yank/kill-ring-entity/kill-ring-entity.ts
@@ -1,4 +1,5 @@
 export interface IKillRingEntity {
+  type: string;
   isSameClipboardText(clipboardText: string): boolean;
   isEmpty(): boolean;
   asString(): string;

--- a/src/kill-yank/kill-ring.ts
+++ b/src/kill-yank/kill-ring.ts
@@ -1,8 +1,11 @@
-import { IKillRingEntity } from "./kill-ring-entity/kill-ring-entity";
+import { ClipboardTextKillRingEntity } from "./kill-ring-entity/clipboard-text";
+import { EditorTextKillRingEntity } from "./kill-ring-entity/editor-text";
+
+export type KillRingEntity = ClipboardTextKillRingEntity | EditorTextKillRingEntity;
 
 export class KillRing {
   private maxNum = 60;
-  private killRing: IKillRingEntity[];
+  private killRing: KillRingEntity[];
   private pointer: number | null;
 
   constructor(maxNum = 60) {
@@ -14,7 +17,7 @@ export class KillRing {
     this.killRing = [];
   }
 
-  public push(entity: IKillRingEntity) {
+  public push(entity: KillRingEntity) {
     this.killRing = [entity].concat(this.killRing);
     if (this.killRing.length > this.maxNum) {
       this.killRing = this.killRing.slice(0, this.maxNum);
@@ -22,7 +25,7 @@ export class KillRing {
     this.pointer = 0;
   }
 
-  public getTop(): IKillRingEntity | null {
+  public getTop(): KillRingEntity | null {
     if (this.pointer === null || this.killRing.length === 0) {
       return null;
     }
@@ -30,7 +33,7 @@ export class KillRing {
     return this.killRing[this.pointer];
   }
 
-  public popNext(): IKillRingEntity | null {
+  public popNext(): KillRingEntity | null {
     if (this.pointer === null || this.killRing.length === 0) {
       return null;
     }


### PR DESCRIPTION
Resolves #494